### PR TITLE
Fix Long Shot not dealing damage after Evade

### DIFF
--- a/backend/arkham-core/library/Arkham/Skill/Cards/LongShot.hs
+++ b/backend/arkham-core/library/Arkham/Skill/Cards/LongShot.hs
@@ -19,4 +19,9 @@ instance RunMessage LongShot where
         EnemyTarget eid -> nonAttackEnemyDamage attrs 1 eid
         _ -> error "invalid target"
       pure s
+    PassedSkillTest _iid (Just Evade) _ (isTarget attrs -> True) _ _ -> do
+      whenJustM getSkillTestTarget \case
+        EnemyTarget eid -> nonAttackEnemyDamage attrs 1 eid
+        _ -> error "invalid target"
+      pure s
     _ -> LongShot <$> liftRunMessage msg attrs


### PR DESCRIPTION
If there's a better way to update this to accept either action type instead of duplicating the logic, let me know how or feel free to change it yourself.

I was at least able to test it locally (after much hassle setting up WSL again) to confirm this change fixes the issue.