### PR TITLE
Fix The Devourer Below scenarios

### DIFF
--- a/backend/arkham-api/library/Arkham/Scenario/Scenarios/ReturnToTheDevourerBelow.hs
+++ b/backend/arkham-api/library/Arkham/Scenario/Scenarios/ReturnToTheDevourerBelow.hs
@@ -78,7 +78,7 @@ instance RunMessage ReturnToTheDevourerBelow where
            , Locations.arkhamWoodsWoodenBridge
            ]
 
-      cultistsWhoGotAway <- getRecordSet CultistsWhoGotAway
+      cultistsWhoGotAway <- getRecordedCardCodes CultistsWhoGotAway
       let placeDoomAmount = (length cultistsWhoGotAway + 1) `div` 2
       pushWhen (placeDoomAmount > 0) $ PlaceDoomOnAgenda placeDoomAmount CanNotAdvance
 

--- a/backend/arkham-api/library/Arkham/Scenario/Scenarios/TheDevourerBelow.hs
+++ b/backend/arkham-api/library/Arkham/Scenario/Scenarios/TheDevourerBelow.hs
@@ -104,7 +104,7 @@ instance RunMessage TheDevourerBelow where
            , Locations.arkhamWoodsQuietGlade
            ]
 
-      cultistsWhoGotAway <- getRecordSet CultistsWhoGotAway
+      cultistsWhoGotAway <- getRecordedCardCodes CultistsWhoGotAway
       let placeDoomAmount = (length cultistsWhoGotAway + 1) `div` 2
       pushWhen (placeDoomAmount > 0) $ PlaceDoomOnAgenda placeDoomAmount CanNotAdvance
 


### PR DESCRIPTION
Fixes the amount of dooms placed on Agenda 1a.

These are the rules from the "Night of the Zealot" Campaign guide:
> Check the number of names recorded under “Cultists Who Got Away” in your Campaign Log.
> - If there are exactly 0 names, no changes are made.
> - If there are exactly 1 or 2 names, place 1 doom on Agenda 1a.
> - If there are exactly 3 or 4 names, place 2 doom on Agenda 1a.
> - If there are exactly 5 or 6 names, place 3 doom on Agenda 1a.

Feel free to change this really small fix, if you know a better solution.