### PR TITLE
Fix arkham.build share URLs

### DIFF
--- a/frontend/src/arkham/components/ArkhamDbDeck.vue
+++ b/frontend/src/arkham/components/ArkhamDbDeck.vue
@@ -20,7 +20,7 @@ function loadDeck() {
   model.value = null
 
   const arkhamDbRegex = /https:\/\/(?:[a-zA-Z0-9-]+\.)?arkhamdb\.com\/(deck(list)?)(\/view)?\/([^/]+)/
-  const arkhamBuildRegex = /https:\/\/arkham\.build\/(deck(list)?)(\/view|share)\/([^/]+)/
+  const arkhamBuildRegex = /https:\/\/arkham\.build\/((deck(list)?\/view)|share)\/([^/]+)/
   
   let matches
   if ((matches = deck.value.match(arkhamDbRegex))) {


### PR DESCRIPTION
This updates the regex for arkham.build URLs - the URL for shares is just `/share`, not `/deck/share`. Given that we don't use match groups 1 - 3, the only thing I did was to make sure that the actual id stays in group 4.