### PR TITLE
Adjust card overlay layout and behavior

### DIFF
--- a/frontend/src/arkham/components/CardOverlay.vue
+++ b/frontend/src/arkham/components/CardOverlay.vue
@@ -7,7 +7,7 @@ import PoolItem from '@/arkham/components/PoolItem.vue';
 
 const cardOverlay = ref<HTMLElement | null>(null)
 const hoveredElement = ref<HTMLElement | null>(null)
-
+let canDisablePress = false
 onMounted(() => {
   const handleMouseover = (event: Event) => {
     const target = event.target as HTMLElement
@@ -23,20 +23,42 @@ onMounted(() => {
       } else {
         hoveredElement.value = target
       }
-    } else {
-      hoveredElement.value = null
+      canDisablePress = true
+    }
+    else{
+      if (!isMobile){
+        hoveredElement.value = null
+      }
     }
   }
 
   const isMobile = window.matchMedia('(hover: none) and (pointer: coarse)').matches;
   let pressTimer : number | undefined = undefined
-
   const handlePress = (event: Event) => {
     pressTimer = setTimeout(() => handleMouseover(event), 200)
-    event.preventDefault()
+    //event.preventDefault()
   }
   const disablePress = () => {
-    hoveredElement.value = null
+    if (canDisablePress) {
+      // disablePress is ready for next click, so reset the flag
+      canDisablePress = false
+    }
+    else{
+      hoveredElement.value = null
+      clearTimeout(pressTimer)
+    }
+  }
+  const filterPress = () => {
+    if (hoveredElement.value?.classList.contains('in-hand')) {
+        hoveredElement.value = null
+    }
+    clearTimeout(pressTimer)
+  }
+
+  const filterMove = () => {
+    if (hoveredElement.value?.classList.contains('card--locations')) {
+        hoveredElement.value = null
+    }
     clearTimeout(pressTimer)
   }
 
@@ -45,7 +67,8 @@ onMounted(() => {
   } else {
     document.addEventListener('contextmenu', e => e.preventDefault());
     document.addEventListener('touchstart', handlePress)
-    document.addEventListener('touchend', disablePress)
+    document.addEventListener('touchmove', filterMove)
+    document.addEventListener('touchend', filterPress)
     document.addEventListener('mouseup', disablePress)
   }
 
@@ -488,10 +511,12 @@ const getImage = (el: HTMLElement): string | null => {
   }
   &.sideways {
     height: 300px !important;
-    width: fit-content !important;
-    height: 300px;
+    //width: fit-content !important;
     //aspect-ratio: var(--card-sideways-aspect);
     width: auto;
+    @media (max-width: 800px) and (orientation: portrait){
+      overflow: auto;
+    }
     img {
       aspect-ratio: var(--card-sideways-aspect);
       border-radius: 15px;
@@ -2032,7 +2057,7 @@ const getImage = (el: HTMLElement): string | null => {
   position: absolute;
   top: 0;
   left: 2px;
-  pointer-events: none;
+  pointer-events: auto;
   animation: fadeIn 0.5s;
 }
 

--- a/frontend/src/arkham/components/HandCard.vue
+++ b/frontend/src/arkham/components/HandCard.vue
@@ -1,8 +1,7 @@
 <script lang="ts" setup>
-import { computed, inject, ref, Ref } from 'vue'
+import { computed, inject, Ref } from 'vue'
 import { CardContents, type Card } from '@/arkham/types/Card'
 import type { Game } from '@/arkham/types/Game'
-import { useDebug } from '@/arkham/debug';
 import type { AbilityLabel, AbilityMessage, Message } from '@/arkham/types/Message'
 import { MessageType} from '@/arkham/types/Message'
 import { imgsrc } from '@/arkham/helpers'
@@ -17,9 +16,6 @@ export interface Props {
 }
 
 const props = defineProps<Props>()
-
-const debug = useDebug()
-const dragging = ref(false)
 
 const investigator = computed(() => Object.values(props.game.investigators).find((i) => i.playerId === props.playerId))
 const investigatorId = computed(() => investigator.value?.id)
@@ -100,15 +96,6 @@ const image = computed(() => {
   const mutatedSuffix = mutated ? `_${mutated}` : ''
   return imgsrc(`cards/${cardCode.replace('c', '')}${mutatedSuffix}.avif`);
 })
-
-function startDrag(event: DragEvent) {
-  dragging.value = true
-  if (event.dataTransfer) {
-    console.log('dragging', id.value)
-    event.dataTransfer.effectAllowed = 'move'
-    event.dataTransfer.setData('text/plain', JSON.stringify({ "tag": "CardIdTarget", "contents": id.value }))
-  }
-}
 
 /*
 const painted = computed(() => {
@@ -235,12 +222,10 @@ function oilPaintEffect(canvas, radius, intensity) {
   <div class="card-container" :data-index="id" v-if="solo || (investigatorId == ownerId) || revealed">
     <img
       :class="classObject"
-      class="card"
+      class="card in-hand"
       :src="image"
       :data-customizations="JSON.stringify(card.contents.customizations)"
       @click="$emit('choose', cardAction)"
-      @dragstart="startDrag($event)"
-      :draggable="debug.active"
     />
 
     <AbilityButton
@@ -254,7 +239,7 @@ function oilPaintEffect(canvas, radius, intensity) {
 
   </div>
   <div class="card-container" v-else>
-    <img class="card" :src="cardBack" />
+    <img class="card in-hand" :src="cardBack" />
   </div>
 </template>
 


### PR DESCRIPTION
- Hand cards (elements with class list containing "in-hand") retain their original overlay behavior.
- Other cards (e.g., location, act, agenda) now keep the overlay visible until the user clicks anywhere.
- Sideways cards now support overflow with scroll.