### PR TITLE
Adjust Hand Area on Mobile Device

### DIFF
--- a/frontend/src/arkham/components/Player.vue
+++ b/frontend/src/arkham/components/Player.vue
@@ -661,7 +661,7 @@ function toggleHandAreaMarginBottom(event: Event) {
           </template>
         </div>
       </div>
-      <div v-if = "!isMobile" class="hand hand-area">
+      <div v-if="!isMobile" class="hand hand-area">
         <transition-group tag="section" class="hand" @enter="onEnter" @leave="onLeave" @before-enter="onBeforeEnter"
           @drop="onDropHand($event)"
           @dragover.prevent="dragover($event)"
@@ -711,7 +711,7 @@ function toggleHandAreaMarginBottom(event: Event) {
         <div v-if="investigator.handSize" class="hand-size" :class="handSizeClasses" :current-length="totalHandSize">Hand Size: {{totalHandSize}}/{{investigator.handSize}}</div>
       </div>
     </div>
-    <div v-if = "isMobile" class="hand hand-area-IsMobile" :style="{ marginBottom: `${handAreaMarginBottom}px` }" @click="toggleHandAreaMarginBottom">
+    <div v-if="isMobile" class="hand hand-area-IsMobile" :style="{ marginBottom: `${handAreaMarginBottom}px` }" @click="toggleHandAreaMarginBottom">
       <transition-group tag="section" class="hand" @enter="onEnter" @leave="onLeave" @before-enter="onBeforeEnter"
         @drop="onDropHand($event)"
         @dragover.prevent="dragover($event)"


### PR DESCRIPTION
By default, the hand is hidden at the bottom, and it should appear when the hand card is clicked.
![handArea](https://github.com/user-attachments/assets/c91a24b4-3a4c-4476-a24e-e7f1470cf125)
