### PR TITLE
Add flavor text to CardOverlay

### DIFF
--- a/frontend/src/stores/dbCards.ts
+++ b/frontend/src/stores/dbCards.ts
@@ -11,6 +11,8 @@ export interface ArkhamDBCard {
   back_traits?: string
   back_text?: string
   customization_text?: string
+  flavor? :string
+  back_flavor?: string
   faction_name: string
   faction2_name?: string
   faction3_name?: string
@@ -20,6 +22,7 @@ export interface ArkhamDBCard {
   real_traits: string
   real_text: string
   type_code: string
+  is_unique: boolean
 }
 
 export interface DbCardsState {


### PR DESCRIPTION
This pull request enhances the handling and display of Arkham card data in the `CardOverlay.vue` component, primarily by adding support for card flavor text and improving the rendering of card attributes. It also refactors the token replacement logic for better reliability and updates the card data model to include new fields.

**Remove text comparison**
If back_text is tranlated, it should be shown regardless if real_text == text. Moreover, it makes bad user experience to read card text when some text are translated and some are not. Even if it shows some english in card overlay, I think it is better way 100% sure.  

**Card flavor support and display:**

* Added support for card flavor text in both the front and back of cards, including new fields `flavor` and `back_flavor` in the `ArkhamDBCard` interface, and logic to extract and render this text in `CardOverlay.vue`. [[1]](diffhunk://#diff-c48ab04752f924eb8d3a1193934ccf395edd7101966c7593adcabec9bf0054e8R14-R15) [[2]](diffhunk://#diff-cf86fe213e66736deae33ca5b6cde7236c8940603da1284f7e6e9e3addfeceb0R330-R377) [[3]](diffhunk://#diff-cf86fe213e66736deae33ca5b6cde7236c8940603da1284f7e6e9e3addfeceb0R452-R453)
* Updated the card overlay template to display flavor text in italic with smaller font size, and to show a line break before flavor text for improved readability.
* I think the flavor text is important part for card text, at least for location card. Sometimes it give us hint how to advance. 

**Card attribute enhancements:**

* Introduced the `is_unique` field in the `ArkhamDBCard` interface and updated the card name rendering logic to prefix unique card names with an asterisk (`*`). [[1]](diffhunk://#diff-c48ab04752f924eb8d3a1193934ccf395edd7101966c7593adcabec9bf0054e8R25) [[2]](diffhunk://#diff-cf86fe213e66736deae33ca5b6cde7236c8940603da1284f7e6e9e3addfeceb0L385-L405)

**Token replacement logic improvements:**

* Refactored the `TOKEN_MAP` and its regular expression construction to remove unnecessary escaping and ensure correct token matching, improving maintainability and reliability of icon replacements in card text. In my container, current version doesn't show icons. Otherwise token map seems need to be somthing like "/\[action\]/g"



