### PR TITLE
Add double-sided card name and trait support

### DIFF
--- a/backend/validate/app/Main.hs
+++ b/backend/validate/app/Main.hs
@@ -60,6 +60,7 @@ data CardJson = CardJson
   , cost :: Maybe Int
   , exceptional :: Bool
   , is_unique :: Bool
+  , double_sided :: Bool
   , traits :: Maybe Text
   , skill_agility :: Maybe Int
   , skill_combat :: Maybe Int

--- a/frontend/src/arkham/components/CardOverlay.vue
+++ b/frontend/src/arkham/components/CardOverlay.vue
@@ -393,7 +393,7 @@ const getCardName = (dbCard: ArkhamDBCard, needBack: boolean): string | null => 
   if (isLocalized(card.value)) return null
 
   if (dbCard.name === dbCard.real_name) return null
-  let name = needBack ? (dbCard.back_name || null) : (dbCard.name || null)
+  let name = (needBack ? (dbCard.double_sided ? (dbCard.back_name || dbCard.name) : dbCard.back_name) : dbCard.name) || null;
   if (!name) return null
   if (!needBack && dbCard.subname) name = `${name}: ${dbCard.subname}`
   if ((dbCard.xp || 0) > 0) name = `${name} (${dbCard.xp})`
@@ -405,7 +405,8 @@ const getCardTraits = (dbCard: ArkhamDBCard, needBack: boolean): string | null =
   if (!card.value) return null
   if (isLocalized(card.value)) return null
 
-  return needBack ? (dbCard.back_traits || null) : (dbCard.traits || null)
+  return (needBack ? (dbCard.double_sided ? (dbCard.back_traits || dbCard.traits) : dbCard.back_traits) : dbCard.traits) || null
+
 }
 
 const getCardText = (dbCard: ArkhamDBCard, needBack: boolean): string | null => {

--- a/frontend/src/stores/dbCards.ts
+++ b/frontend/src/stores/dbCards.ts
@@ -23,6 +23,7 @@ export interface ArkhamDBCard {
   real_text: string
   type_code: string
   is_unique: boolean
+  double_sided: boolean
 }
 
 export interface DbCardsState {


### PR DESCRIPTION
Add double_sided information for CardOverlay. 

It is mainly for showing card name and trait for flipped location card. 

most of location cards has backside, but same name with both side. which means there is no back_name and back_trait. 

This change allows to show same name and trait for both side, based on the value of double_sided. 