### PR TITLE
Fix spellbound effect handling (TMG)

### DIFF
--- a/backend/arkham-api/library/Arkham/Asset/Assets/ArchibaldHudson.hs
+++ b/backend/arkham-api/library/Arkham/Asset/Assets/ArchibaldHudson.hs
@@ -6,13 +6,17 @@ import Arkham.Asset.Import.Lifted
 import Arkham.Matcher hiding (DuringTurn)
 import Arkham.Message.Lifted.Choose
 import Arkham.Strategy
+import Arkham.Scenarios.TheMidwinterGala.Helpers
 
 newtype ArchibaldHudson = ArchibaldHudson AssetAttrs
-  deriving anyclass (IsAsset, HasModifiersFor)
+  deriving anyclass IsAsset
   deriving newtype (Show, Eq, ToJSON, FromJSON, Entity)
 
 archibaldHudson :: AssetCard ArchibaldHudson
 archibaldHudson = allyWith ArchibaldHudson Cards.archibaldHudson (2, 2) noSlots
+
+instance HasModifiersFor ArchibaldHudson where
+  getModifiersFor (ArchibaldHudson a) = handleSpellbound a
 
 instance HasAbilities ArchibaldHudson where
   getAbilities (ArchibaldHudson a) =
@@ -47,8 +51,8 @@ instance RunMessage ArchibaldHudson where
         chooseTargetM iid enemies \eid -> moveTokens (attrs.ability 2) aid eid #damage 1
       pure a
     Flip _ ScenarioSource (isTarget attrs -> True) -> do
-      pure $ ArchibaldHudson $ attrs & flippedL .~ True & visibleL .~ False
+      pure $ ArchibaldHudson $ attrs & flippedL .~ True & visibleL .~ False & setMeta True
     Flip _ _ (isTarget attrs -> True) -> do
       let flipped = not $ view flippedL attrs
-      pure $ ArchibaldHudson $ attrs & flippedL .~ flipped & visibleL .~ True
+      pure $ ArchibaldHudson $ attrs & flippedL .~ flipped & visibleL .~ True & setMeta False
     _ -> ArchibaldHudson <$> liftRunMessage msg attrs

--- a/backend/arkham-api/library/Arkham/Asset/Assets/ArseneRenard.hs
+++ b/backend/arkham-api/library/Arkham/Asset/Assets/ArseneRenard.hs
@@ -8,13 +8,17 @@ import Arkham.I18n
 import Arkham.Matcher
 import Arkham.Message.Lifted.Choose
 import Arkham.Token qualified as Token
+import Arkham.Scenarios.TheMidwinterGala.Helpers
 
 newtype ArseneRenard = ArseneRenard AssetAttrs
-  deriving anyclass (IsAsset, HasModifiersFor)
+  deriving anyclass IsAsset
   deriving newtype (Show, Eq, ToJSON, FromJSON, Entity)
 
 arseneRenard :: AssetCard ArseneRenard
 arseneRenard = allyWith ArseneRenard Cards.arseneRenard (1, 3) noSlots
+
+instance HasModifiersFor ArseneRenard where
+  getModifiersFor (ArseneRenard a) = handleSpellbound a
 
 instance HasAbilities ArseneRenard where
   getAbilities (ArseneRenard a) =
@@ -40,8 +44,8 @@ instance RunMessage ArseneRenard where
         countVar 2 $ labeled' "gainResources" $ gainResources iid (attrs.ability 2) 2
       pure a
     Flip _ ScenarioSource (isTarget attrs -> True) -> do
-      pure $ ArseneRenard $ attrs & flippedL .~ True & visibleL .~ False
+      pure $ ArseneRenard $ attrs & flippedL .~ True & visibleL .~ False & setMeta True
     Flip _ _ (isTarget attrs -> True) -> do
       let flipped = not $ view flippedL attrs
-      pure $ ArseneRenard $ attrs & flippedL .~ flipped & visibleL .~ True
+      pure $ ArseneRenard $ attrs & flippedL .~ flipped & visibleL .~ True & setMeta False
     _ -> ArseneRenard <$> liftRunMessage msg attrs

--- a/backend/arkham-api/library/Arkham/Asset/Assets/ClaireWilson.hs
+++ b/backend/arkham-api/library/Arkham/Asset/Assets/ClaireWilson.hs
@@ -6,13 +6,17 @@ import Arkham.Asset.Import.Lifted
 import Arkham.Helpers.SkillTest (withSkillTest)
 import Arkham.Matcher
 import Arkham.Modifier
+import Arkham.Scenarios.TheMidwinterGala.Helpers
 
 newtype ClaireWilson = ClaireWilson AssetAttrs
-  deriving anyclass (IsAsset, HasModifiersFor)
+  deriving anyclass IsAsset
   deriving newtype (Show, Eq, ToJSON, FromJSON, Entity)
 
 claireWilson :: AssetCard ClaireWilson
 claireWilson = allyWith ClaireWilson Cards.claireWilson (2, 2) noSlots
+
+instance HasModifiersFor ClaireWilson where
+  getModifiersFor (ClaireWilson a) = handleSpellbound a
 
 instance HasAbilities ClaireWilson where
   getAbilities (ClaireWilson a) =
@@ -26,8 +30,8 @@ instance RunMessage ClaireWilson where
       withSkillTest \sid -> skillTestModifier sid (attrs.ability 1) iid (AnySkillValue 1)
       pure a
     Flip _ ScenarioSource (isTarget attrs -> True) -> do
-      pure $ ClaireWilson $ attrs & flippedL .~ True & visibleL .~ False
+      pure $ ClaireWilson $ attrs & flippedL .~ True & visibleL .~ False & setMeta True
     Flip _ _ (isTarget attrs -> True) -> do
       let flipped = not $ view flippedL attrs
-      pure $ ClaireWilson $ attrs & flippedL .~ flipped & visibleL .~ True
+      pure $ ClaireWilson $ attrs & flippedL .~ flipped & visibleL .~ True & setMeta False
     _ -> ClaireWilson <$> liftRunMessage msg attrs

--- a/backend/arkham-api/library/Arkham/Asset/Assets/DeloresGadling.hs
+++ b/backend/arkham-api/library/Arkham/Asset/Assets/DeloresGadling.hs
@@ -6,6 +6,7 @@ import Arkham.Helpers.Modifiers (ModifierType (..), controllerGets, maybeModifie
 import Arkham.Helpers.SkillTest (isInvestigation, isParley)
 import Arkham.Matcher
 import Arkham.Trait
+import Arkham.Scenarios.TheMidwinterGala.Helpers
 
 newtype DeloresGadling = DeloresGadling AssetAttrs
   deriving anyclass (IsAsset, HasAbilities)
@@ -22,12 +23,13 @@ instance HasModifiersFor DeloresGadling where
       n <- selectCount $ EnemyAt YourLocation <> EnemyWithTrait Humanoid
       guard (n > 0)
       pure [SkillModifier #intellect n]
+    handleSpellbound a
 
 instance RunMessage DeloresGadling where
   runMessage msg (DeloresGadling attrs) = runQueueT $ case msg of
     Flip _ ScenarioSource (isTarget attrs -> True) -> do
-      pure $ DeloresGadling $ attrs & flippedL .~ True & visibleL .~ False
+      pure $ DeloresGadling $ attrs & flippedL .~ True & visibleL .~ False & setMeta True
     Flip _ _ (isTarget attrs -> True) -> do
       let flipped = not $ view flippedL attrs
-      pure $ DeloresGadling $ attrs & flippedL .~ flipped & visibleL .~ True
+      pure $ DeloresGadling $ attrs & flippedL .~ flipped & visibleL .~ True & setMeta False
     _ -> DeloresGadling <$> liftRunMessage msg attrs

--- a/backend/arkham-api/library/Arkham/Asset/Assets/DrMyaBadry.hs
+++ b/backend/arkham-api/library/Arkham/Asset/Assets/DrMyaBadry.hs
@@ -6,6 +6,7 @@ import Arkham.Asset.Import.Lifted
 import Arkham.Helpers.Modifiers (ModifierType (..), controllerGets)
 import Arkham.Investigator.Types (Field (..))
 import Arkham.Projection
+import Arkham.Scenarios.TheMidwinterGala.Helpers
 
 newtype DrMyaBadry = DrMyaBadry AssetAttrs
   deriving anyclass IsAsset
@@ -15,7 +16,9 @@ drMyaBadry :: AssetCard DrMyaBadry
 drMyaBadry = allyWith DrMyaBadry Cards.drMyaBadry (2, 2) noSlots
 
 instance HasModifiersFor DrMyaBadry where
-  getModifiersFor (DrMyaBadry a) = controllerGets a [HandSize 2]
+  getModifiersFor (DrMyaBadry a) = do
+    controllerGets a [HandSize 2]
+    handleSpellbound a
 
 instance HasAbilities DrMyaBadry where
   getAbilities (DrMyaBadry a) = [investigateAbility a 1 (exhaust a) ControlsThis]
@@ -29,8 +32,8 @@ instance RunMessage DrMyaBadry where
       investigate sid iid (attrs.ability 1)
       pure a
     Flip _ ScenarioSource (isTarget attrs -> True) -> do
-      pure $ DrMyaBadry $ attrs & flippedL .~ True & visibleL .~ False
+      pure $ DrMyaBadry $ attrs & flippedL .~ True & visibleL .~ False & setMeta True
     Flip _ _ (isTarget attrs -> True) -> do
       let flipped = not $ view flippedL attrs
-      pure $ DrMyaBadry $ attrs & flippedL .~ flipped & visibleL .~ True
+      pure $ DrMyaBadry $ attrs & flippedL .~ flipped & visibleL .~ True & setMeta False
     _ -> DrMyaBadry <$> liftRunMessage msg attrs

--- a/backend/arkham-api/library/Arkham/Asset/Assets/ElizabethConrad.hs
+++ b/backend/arkham-api/library/Arkham/Asset/Assets/ElizabethConrad.hs
@@ -7,13 +7,17 @@ import Arkham.Helpers.Location (getAccessibleLocations)
 import Arkham.Matcher hiding (DuringTurn)
 import Arkham.Message.Lifted.Choose
 import Arkham.Message.Lifted.Move (moveTo)
+import Arkham.Scenarios.TheMidwinterGala.Helpers
 
 newtype ElizabethConrad = ElizabethConrad AssetAttrs
-  deriving anyclass (IsAsset, HasModifiersFor)
+  deriving anyclass IsAsset
   deriving newtype (Show, Eq, ToJSON, FromJSON, Entity)
 
 elizabethConrad :: AssetCard ElizabethConrad
 elizabethConrad = allyWith ElizabethConrad Cards.elizabethConrad (1, 3) noSlots
+
+instance HasModifiersFor ElizabethConrad where
+  getModifiersFor (ElizabethConrad a) = handleSpellbound a
 
 instance HasAbilities ElizabethConrad where
   getAbilities (ElizabethConrad a) =
@@ -31,8 +35,8 @@ instance RunMessage ElizabethConrad where
           moveTo (attrs.ability 1) iid' lid
       pure a
     Flip _ ScenarioSource (isTarget attrs -> True) -> do
-      pure $ ElizabethConrad $ attrs & flippedL .~ True & visibleL .~ False
+      pure $ ElizabethConrad $ attrs & flippedL .~ True & visibleL .~ False & setMeta True
     Flip _ _ (isTarget attrs -> True) -> do
       let flipped = not $ view flippedL attrs
-      pure $ ElizabethConrad $ attrs & flippedL .~ flipped & visibleL .~ True
+      pure $ ElizabethConrad $ attrs & flippedL .~ flipped & visibleL .~ True & setMeta False
     _ -> ElizabethConrad <$> liftRunMessage msg attrs

--- a/backend/arkham-api/library/Arkham/Asset/Assets/HoracioMartinez.hs
+++ b/backend/arkham-api/library/Arkham/Asset/Assets/HoracioMartinez.hs
@@ -6,6 +6,7 @@ import Arkham.Asset.Import.Lifted hiding (EnemyAttacks)
 import Arkham.Helpers.Modifiers (ModifierType (..), modifySelect)
 import Arkham.Helpers.Window (getAttackDetails)
 import Arkham.Matcher
+import Arkham.Scenarios.TheMidwinterGala.Helpers
 
 newtype HoracioMartinez = HoracioMartinez AssetAttrs
   deriving anyclass IsAsset
@@ -15,8 +16,10 @@ horacioMartinez :: AssetCard HoracioMartinez
 horacioMartinez = allyWith HoracioMartinez Cards.horacioMartinez (4, 1) noSlots
 
 instance HasModifiersFor HoracioMartinez where
-  getModifiersFor (HoracioMartinez a) = for_ a.controller \iid ->
-    modifySelect a (notInvestigator iid <> colocatedWith iid) [CanAssignDamageToAsset a.id]
+  getModifiersFor (HoracioMartinez a) = do
+    for_ a.controller \iid ->
+      modifySelect a (notInvestigator iid <> colocatedWith iid) [CanAssignDamageToAsset a.id]
+    handleSpellbound a
 
 instance HasAbilities HoracioMartinez where
   getAbilities (HoracioMartinez a) =
@@ -29,8 +32,8 @@ instance RunMessage HoracioMartinez where
       roundModifier (attrs.ability 1) attack.enemy CannotReady
       pure a
     Flip _ ScenarioSource (isTarget attrs -> True) -> do
-      pure $ HoracioMartinez $ attrs & flippedL .~ True & visibleL .~ False
+      pure $ HoracioMartinez $ attrs & flippedL .~ True & visibleL .~ False & setMeta True
     Flip _ _ (isTarget attrs -> True) -> do
       let flipped = not $ view flippedL attrs
-      pure $ HoracioMartinez $ attrs & flippedL .~ flipped & visibleL .~ True
+      pure $ HoracioMartinez $ attrs & flippedL .~ flipped & visibleL .~ True & setMeta False
     _ -> HoracioMartinez <$> liftRunMessage msg attrs

--- a/backend/arkham-api/library/Arkham/Asset/Assets/LucasTetlow.hs
+++ b/backend/arkham-api/library/Arkham/Asset/Assets/LucasTetlow.hs
@@ -8,13 +8,17 @@ import Arkham.Matcher
 import Arkham.Message.Lifted.Choose
 import Arkham.Strategy
 import Arkham.Trait
+import Arkham.Scenarios.TheMidwinterGala.Helpers
 
 newtype LucasTetlow = LucasTetlow AssetAttrs
-  deriving anyclass (IsAsset, HasModifiersFor)
+  deriving anyclass IsAsset
   deriving newtype (Show, Eq, ToJSON, FromJSON, Entity)
 
 lucasTetlow :: AssetCard LucasTetlow
 lucasTetlow = allyWith LucasTetlow Cards.lucasTetlow (3, 1) noSlots
+
+instance HasModifiersFor LucasTetlow where
+  getModifiersFor (LucasTetlow a) = handleSpellbound a
 
 instance HasAbilities LucasTetlow where
   getAbilities (LucasTetlow a) =
@@ -51,8 +55,8 @@ instance RunMessage LucasTetlow where
       for_ attrs.controller shuffleDeck
       pure a
     Flip _ ScenarioSource (isTarget attrs -> True) -> do
-      pure $ LucasTetlow $ attrs & flippedL .~ True & visibleL .~ False
+      pure $ LucasTetlow $ attrs & flippedL .~ True & visibleL .~ False & setMeta True
     Flip _ _ (isTarget attrs -> True) -> do
       let flipped = not $ view flippedL attrs
-      pure $ LucasTetlow $ attrs & flippedL .~ flipped & visibleL .~ True
+      pure $ LucasTetlow $ attrs & flippedL .~ flipped & visibleL .~ True & setMeta False
     _ -> LucasTetlow <$> liftRunMessage msg attrs

--- a/backend/arkham-api/library/Arkham/Asset/Assets/MirandaKeeper.hs
+++ b/backend/arkham-api/library/Arkham/Asset/Assets/MirandaKeeper.hs
@@ -9,13 +9,17 @@ import Arkham.Helpers.Modifiers (ModifierType (..))
 import Arkham.Matcher
 import Arkham.Script (yourNextSkillTest)
 import Arkham.Token qualified as Token
+import Arkham.Scenarios.TheMidwinterGala.Helpers
 
 newtype MirandaKeeper = MirandaKeeper AssetAttrs
-  deriving anyclass (IsAsset, HasModifiersFor)
+  deriving anyclass IsAsset
   deriving newtype (Show, Eq, ToJSON, FromJSON, Entity)
 
 mirandaKeeper :: AssetCard MirandaKeeper
 mirandaKeeper = allyWith MirandaKeeper Cards.mirandaKeeper (2, 2) noSlots
+
+instance HasModifiersFor MirandaKeeper where
+  getModifiersFor (MirandaKeeper a) = handleSpellbound a
 
 instance HasAbilities MirandaKeeper where
   getAbilities (MirandaKeeper a) =
@@ -38,8 +42,8 @@ instance RunMessage MirandaKeeper where
       gainResources iid (attrs.ability 2) 2
       pure a
     Flip _ ScenarioSource (isTarget attrs -> True) -> do
-      pure $ MirandaKeeper $ attrs & flippedL .~ True & visibleL .~ False
+      pure $ MirandaKeeper $ attrs & flippedL .~ True & visibleL .~ False & setMeta True
     Flip _ _ (isTarget attrs -> True) -> do
       let flipped = not $ view flippedL attrs
-      pure $ MirandaKeeper $ attrs & flippedL .~ flipped & visibleL .~ True
+      pure $ MirandaKeeper $ attrs & flippedL .~ flipped & visibleL .~ True & setMeta False
     _ -> MirandaKeeper <$> liftRunMessage msg attrs

--- a/backend/arkham-api/library/Arkham/Asset/Assets/NovaMalone.hs
+++ b/backend/arkham-api/library/Arkham/Asset/Assets/NovaMalone.hs
@@ -6,13 +6,17 @@ import Arkham.Asset.Import.Lifted hiding (EnemyDefeated)
 import Arkham.Investigator.Types (Field (..))
 import Arkham.Matcher
 import Arkham.Modifier
+import Arkham.Scenarios.TheMidwinterGala.Helpers
 
 newtype NovaMalone = NovaMalone AssetAttrs
-  deriving anyclass (IsAsset, HasModifiersFor)
+  deriving anyclass IsAsset
   deriving newtype (Show, Eq, ToJSON, FromJSON, Entity)
 
 novaMalone :: AssetCard NovaMalone
 novaMalone = allyWith NovaMalone Cards.novaMalone (3, 1) noSlots
+
+instance HasModifiersFor NovaMalone where
+  getModifiersFor (NovaMalone a) = handleSpellbound a
 
 instance HasAbilities NovaMalone where
   getAbilities (NovaMalone a) =
@@ -40,8 +44,8 @@ instance RunMessage NovaMalone where
       gainResources iid (attrs.ability 2) 1
       pure a
     Flip _ ScenarioSource (isTarget attrs -> True) -> do
-      pure $ NovaMalone $ attrs & flippedL .~ True & visibleL .~ False
+      pure $ NovaMalone $ attrs & flippedL .~ True & visibleL .~ False & setMeta True
     Flip _ _ (isTarget attrs -> True) -> do
       let flipped = not $ view flippedL attrs
-      pure $ NovaMalone $ attrs & flippedL .~ flipped & visibleL .~ True
+      pure $ NovaMalone $ attrs & flippedL .~ flipped & visibleL .~ True & setMeta False
     _ -> NovaMalone <$> liftRunMessage msg attrs

--- a/backend/arkham-api/library/Arkham/Asset/Assets/PrudenceDouglas.hs
+++ b/backend/arkham-api/library/Arkham/Asset/Assets/PrudenceDouglas.hs
@@ -10,13 +10,17 @@ import Arkham.Message.Lifted.Choose
 import Arkham.Strategy
 import Arkham.Token (Token (Portent))
 import Arkham.Trait (Trait (Elite), toTraits)
+import Arkham.Scenarios.TheMidwinterGala.Helpers
 
 newtype PrudenceDouglas = PrudenceDouglas AssetAttrs
-  deriving anyclass (IsAsset, HasModifiersFor)
+  deriving anyclass IsAsset
   deriving newtype (Show, Eq, ToJSON, FromJSON, Entity)
 
 prudenceDouglas :: AssetCard PrudenceDouglas
 prudenceDouglas = allyWith PrudenceDouglas Cards.prudenceDouglas (2, 2) noSlots
+
+instance HasModifiersFor PrudenceDouglas where
+  getModifiersFor (PrudenceDouglas a) = handleSpellbound a
 
 instance HasAbilities PrudenceDouglas where
   getAbilities (PrudenceDouglas a) =
@@ -43,8 +47,8 @@ instance RunMessage PrudenceDouglas where
           targets discardable $ \c -> push $ AddToEncounterDiscard c
       pure a
     Flip _ ScenarioSource (isTarget attrs -> True) -> do
-      pure $ PrudenceDouglas $ attrs & flippedL .~ True & visibleL .~ False
+      pure $ PrudenceDouglas $ attrs & flippedL .~ True & visibleL .~ False & setMeta True
     Flip _ _ (isTarget attrs -> True) -> do
       let flipped = not $ view flippedL attrs
-      pure $ PrudenceDouglas $ attrs & flippedL .~ flipped & visibleL .~ True
+      pure $ PrudenceDouglas $ attrs & flippedL .~ flipped & visibleL .~ True & setMeta False
     _ -> PrudenceDouglas <$> liftRunMessage msg attrs

--- a/backend/arkham-api/library/Arkham/Asset/Assets/RaymondLoggins.hs
+++ b/backend/arkham-api/library/Arkham/Asset/Assets/RaymondLoggins.hs
@@ -6,13 +6,17 @@ import Arkham.Asset.Import.Lifted
 import Arkham.Helpers.Window (cardDrawn)
 import Arkham.Matcher
 import Arkham.Token (Token (Truth))
+import Arkham.Scenarios.TheMidwinterGala.Helpers
 
 newtype RaymondLoggins = RaymondLoggins AssetAttrs
-  deriving anyclass (IsAsset, HasModifiersFor)
+  deriving anyclass IsAsset
   deriving newtype (Show, Eq, ToJSON, FromJSON, Entity)
 
 raymondLoggins :: AssetCard RaymondLoggins
 raymondLoggins = allyWith RaymondLoggins Cards.raymondLoggins (1, 2) noSlots
+
+instance HasModifiersFor RaymondLoggins where
+  getModifiersFor (RaymondLoggins a) = handleSpellbound a
 
 instance HasAbilities RaymondLoggins where
   getAbilities (RaymondLoggins a) =
@@ -31,8 +35,8 @@ instance RunMessage RaymondLoggins where
       assignHorror iid attrs 1
       pure a
     Flip _ ScenarioSource (isTarget attrs -> True) -> do
-      pure $ RaymondLoggins $ attrs & flippedL .~ True & visibleL .~ False
+      pure $ RaymondLoggins $ attrs & flippedL .~ True & visibleL .~ False & setMeta True
     Flip _ _ (isTarget attrs -> True) -> do
       let flipped = not $ view flippedL attrs
-      pure $ RaymondLoggins $ attrs & flippedL .~ flipped & visibleL .~ True
+      pure $ RaymondLoggins $ attrs & flippedL .~ flipped & visibleL .~ True & setMeta False
     _ -> RaymondLoggins <$> liftRunMessage msg attrs

--- a/backend/arkham-api/library/Arkham/Asset/Assets/SarahVanShaw.hs
+++ b/backend/arkham-api/library/Arkham/Asset/Assets/SarahVanShaw.hs
@@ -7,7 +7,7 @@ import Arkham.Modifier
 import Arkham.Scenarios.TheMidwinterGala.Helpers
 
 newtype SarahVanShaw = SarahVanShaw AssetAttrs
-  deriving anyclass (IsAsset)
+  deriving anyclass IsAsset
   deriving newtype (Show, Eq, ToJSON, FromJSON, Entity)
 
 sarahVanShaw :: AssetCard SarahVanShaw

--- a/backend/arkham-api/library/Arkham/Asset/Assets/SpecialAgentCallahan.hs
+++ b/backend/arkham-api/library/Arkham/Asset/Assets/SpecialAgentCallahan.hs
@@ -7,13 +7,17 @@ import Arkham.Matcher
 import Arkham.Message.Lifted.Choose
 import Arkham.Modifier
 import Arkham.Trait (Trait (Ally, Weapon))
+import Arkham.Scenarios.TheMidwinterGala.Helpers
 
 newtype SpecialAgentCallahan = SpecialAgentCallahan AssetAttrs
-  deriving anyclass (IsAsset, HasModifiersFor)
+  deriving anyclass IsAsset
   deriving newtype (Show, Eq, ToJSON, FromJSON, Entity)
 
 specialAgentCallahan :: AssetCard SpecialAgentCallahan
 specialAgentCallahan = allyWith SpecialAgentCallahan Cards.specialAgentCallahan (3, 1) noSlots
+
+instance HasModifiersFor SpecialAgentCallahan where
+  getModifiersFor (SpecialAgentCallahan a) = handleSpellbound a
 
 instance HasAbilities SpecialAgentCallahan where
   getAbilities (SpecialAgentCallahan a) =
@@ -40,8 +44,8 @@ instance RunMessage SpecialAgentCallahan where
         nonAttackEnemyDamage (Just iid) (attrs.ability 2) 1 enemy
       pure a
     Flip _ ScenarioSource (isTarget attrs -> True) -> do
-      pure $ SpecialAgentCallahan $ attrs & flippedL .~ True & visibleL .~ False
+      pure $ SpecialAgentCallahan $ attrs & flippedL .~ True & visibleL .~ False & setMeta True
     Flip _ _ (isTarget attrs -> True) -> do
       let flipped = not $ view flippedL attrs
-      pure $ SpecialAgentCallahan $ attrs & flippedL .~ flipped & visibleL .~ True
+      pure $ SpecialAgentCallahan $ attrs & flippedL .~ flipped & visibleL .~ True & setMeta False
     _ -> SpecialAgentCallahan <$> liftRunMessage msg attrs

--- a/backend/arkham-api/library/Arkham/Asset/Assets/ThomasOlney.hs
+++ b/backend/arkham-api/library/Arkham/Asset/Assets/ThomasOlney.hs
@@ -7,13 +7,17 @@ import Arkham.Card
 import Arkham.Helpers.SkillTest
 import Arkham.Matcher
 import Arkham.Trait
+import Arkham.Scenarios.TheMidwinterGala.Helpers
 
 newtype ThomasOlney = ThomasOlney AssetAttrs
-  deriving anyclass (IsAsset, HasModifiersFor)
+  deriving anyclass IsAsset
   deriving newtype (Show, Eq, ToJSON, FromJSON, Entity)
 
 thomasOlney :: AssetCard ThomasOlney
 thomasOlney = ally ThomasOlney Cards.thomasOlney (3, 1)
+
+instance HasModifiersFor ThomasOlney where
+  getModifiersFor (ThomasOlney a) = handleSpellbound a
 
 instance HasAbilities ThomasOlney where
   getAbilities (ThomasOlney a) =
@@ -41,8 +45,8 @@ instance RunMessage ThomasOlney where
       whenM (getIsCommittable iid (toCard card)) $ commitCard iid card
       pure a
     Flip _ ScenarioSource (isTarget attrs -> True) -> do
-      pure $ ThomasOlney $ attrs & flippedL .~ True & visibleL .~ False
+      pure $ ThomasOlney $ attrs & flippedL .~ True & visibleL .~ False & setMeta True
     Flip _ _ (isTarget attrs -> True) -> do
       let flipped = not $ view flippedL attrs
-      pure $ ThomasOlney $ attrs & flippedL .~ flipped & visibleL .~ True
+      pure $ ThomasOlney $ attrs & flippedL .~ flipped & visibleL .~ True & setMeta False
     _ -> ThomasOlney <$> liftRunMessage msg attrs


### PR DESCRIPTION
The spellbound effect handling is missing from most of the TMG guest assets.

After this fix, the following ability can be activated:
- "The Pale Lantern (Beguiling Aura)" [71046b]:
	- Card ability 1: "Flip over a spellbound card at your location."

_Issue: https://github.com/halogenandtoast/ArkhamHorror/issues/3311_