### PR TITLE
Fix "No resolution" text reference (TMG)

### DIFF
--- a/backend/arkham-api/library/Arkham/Scenario/Scenarios/TheMidwinterGala.hs
+++ b/backend/arkham-api/library/Arkham/Scenario/Scenarios/TheMidwinterGala.hs
@@ -308,7 +308,7 @@ instance RunMessage TheMidwinterGala where
     Do (ScenarioResolution r) -> scope "resolutions" do
       case r of
         NoResolution -> do
-          resolution "noResolutions" >> do_ R7
+          resolution "noResolution" >> do_ R7
         Resolution 1 -> do
           let Meta {ally} = toResult attrs.meta
           storyBuild do


### PR DESCRIPTION
Issue:
<img width="603" height="266" alt="image" src="https://github.com/user-attachments/assets/14481593-7d9d-4039-8911-5ecfe0dd9897" />

Based on the other scenario and locale files "noResolutions" was just a typo.