### PR TITLE
Update the Manual Setup in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ mkdir -p arkham-horror/config arkham-horror/scripts arkham-horror/frontend/publi
 cd arkham-horror
 curl -fsSL https://raw.githubusercontent.com/halogenandtoast/ArkhamHorror/main/docker-compose.yml -o docker-compose.yml
 curl -fsSL https://raw.githubusercontent.com/halogenandtoast/ArkhamHorror/main/setup.sql -o setup.sql
-curl -fsSL https://raw.githubusercontent.com/halogenandtoast/ArkhamHorror/main/scripts/fetch-assets.sh -o fetch-assets.sh
+curl -fsSL https://raw.githubusercontent.com/halogenandtoast/ArkhamHorror/main/scripts/fetch-assets.sh -o scripts/fetch-assets.sh
 # Generate a strong password
 openssl rand -base64 32 > config/postgres_password.txt
 docker compose up -d


### PR DESCRIPTION
A step to download the `scripts/fetch-assets.sh` script file from the repository has been added to the manual setup, enabling the correct use of the script file to download resources.