### PR TITLE
Fix/3992 taboo_id to meta.extra_deck cards during decklist loading

### DIFF
--- a/backend/arkham-api/arkham-api.cabal
+++ b/backend/arkham-api/arkham-api.cabal
@@ -5705,6 +5705,7 @@ test-suite spec
       Arkham.Campaign.TheCircleUndone.ScenariosSpec
       Arkham.Campaign.TheDunwichLegacy.ScenariosSpec
       Arkham.Campaign.ThePathToCarcosa.ScenariosSpec
+      Arkham.DecklistSpec
       Arkham.Enemy.Cards.GuardianOfTheCrystallizerSpec
       Arkham.Enemy.Cards.MobEnforcerSpec
       Arkham.Enemy.Cards.SilverTwilightAcolyteSpec

--- a/backend/arkham-api/library/Arkham/Decklist.hs
+++ b/backend/arkham-api/library/Arkham/Decklist.hs
@@ -1,6 +1,6 @@
 module Arkham.Decklist (module Arkham.Decklist, module Arkham.Decklist.Type) where
 
-import Arkham.Card
+import Arkham.Card hiding (setTaboo)
 import Arkham.Card.PlayerCard
 import Arkham.Customization
 import Arkham.Decklist.Type
@@ -67,7 +67,7 @@ loadDecklistCards f decklist =
       genPlayerCardWith (lookupPlayerCardDef cardCode)
         $ applyCustomizations decklist
         . setPlayerCardOwner (normalizeInvestigatorId $ decklistInvestigatorId decklist)
-        . Arkham.Card.PlayerCard.setTaboo (fromTabooId $ taboo_id decklist)
+        . setTaboo (fromTabooId $ taboo_id decklist)
 
 loadExtraDeck :: CardGen m => ArkhamDBDecklist -> m [PlayerCard]
 loadExtraDeck decklist = do
@@ -84,7 +84,7 @@ loadExtraDeck decklist = do
       let convert =
             applyCustomizations decklist
               . setPlayerCardOwner (normalizeInvestigatorId $ decklistInvestigatorId decklist)
-              . Arkham.Card.PlayerCard.setTaboo (fromTabooId $ taboo_id decklist)
+              . setTaboo (fromTabooId $ taboo_id decklist)
       traverse ((`genPlayerCardWith` convert) . lookupPlayerCardDef . CardCode) codes
 
 -- things we can choose: cards, traits, skills

--- a/backend/arkham-api/tests/Arkham/DecklistSpec.hs
+++ b/backend/arkham-api/tests/Arkham/DecklistSpec.hs
@@ -40,7 +40,7 @@ extraDeckDecklist =
     , investigator_code = "90049"
     , investigator_name = "Jim Culver"
     , meta = Just "{\"extra_deck\":\"05153\"}"
-    , taboo_id = Just 23
+    , taboo_id = Just 8
     , url = Nothing
     }
 
@@ -52,6 +52,6 @@ sideSlotsDecklist =
     , investigator_code = "90049"
     , investigator_name = "Jim Culver"
     , meta = Nothing
-    , taboo_id = Just 23
+    , taboo_id = Just 8
     , url = Nothing
     }


### PR DESCRIPTION
Title:
Apply taboo_id to meta.extra_deck cards during decklist loading

Issue ID: 3992
https://github.com/halogenandtoast/ArkhamHorror/issues/3992

Summary:
This fixes decklist loading so cards loaded from `meta.extra_deck` receive `taboo_id` exactly the same way cards loaded from main-deck `slots` and `sideSlots` already do.

Problem:
The bug showed up with side-deck style cards serialized through `meta.extra_deck`, such as Parallel Jim Culver spirit-deck cards. That code path applied owner and customizations, but never applied `taboo_id`, so taboo-sensitive cards were loaded as their original versions.

For example, `Mr. Rook` loaded from `meta.extra_deck` ended up with `tabooList = null` and `mutated = null`, even when the investigator deck itself was using `TabooList23`.

Change:

Added `Arkham.Card.PlayerCard.setTaboo (fromTabooId $ taboo_id decklist)` to the `meta.extra_deck` branch of `loadExtraDeck`
Kept the existing `sideSlots` path unchanged
Added regression coverage for both:
- `meta.extra_deck` applying taboo correctly
- `sideSlots` continuing to apply taboo correctly

Implementation references:
This change follows the same decklist-loading pattern already used by existing card-loading logic in:

`loadDecklistCards`
main-deck `slots`
extra-deck `sideSlots`

Files changed:

backend/arkham-api/library/Arkham/Decklist.hs
backend/arkham-api/tests/Arkham/DecklistSpec.hs

Test coverage:
Added regression coverage for:

loading `05153` from `meta.extra_deck` with `taboo_id = 23` sets `pcTabooList = Just TabooList23`
loading `05153` from `meta.extra_deck` with `taboo_id = 23` sets `pcMutated = Just "Mutated20"`
loading the same card from `sideSlots` still preserves the existing taboo behavior

Validation:
Ran:
stack test arkham-api:spec --test-arguments='--match "loadDecklist"'

Result:
I started a new campaign with the same imported deck. Mr.Rook is now tabooed correctly from the spirit deck.
<img width="677" height="552" alt="Screenshot 2026-04-01 at 10 35 43 AM" src="https://github.com/user-attachments/assets/3a2d0d19-79d4-46c4-a62b-0c01f1d22079" />

