### PR TITLE
Fix/3994 Route host damage to swarm cards before defeating swarming enemies

### DIFF
--- a/backend/arkham-api/library/Arkham/Enemy/Runner.hs
+++ b/backend/arkham-api/library/Arkham/Enemy/Runner.hs
@@ -1366,18 +1366,36 @@ instance RunMessage EnemyAttrs where
       push afterWindow
       pure $ a & tokensL %~ removeAllTokens Token.Damage & defeatedL .~ False
     Msg.EnemyDamage eid damageAssignment | eid == enemyId -> do
-      let
-        source = damageAssignmentSource damageAssignment
-        damageEffect = damageAssignmentDamageEffect damageAssignment
-        damageAmount = damageAssignmentAmount damageAssignment
-      canDamage <- sourceCanDamageEnemy eid source
-      when canDamage do
-        Lifted.checkWhen $ Window.WouldTakeDamage source (toTarget a) damageAmount DamageDirect
-        Lifted.checkWhen $ Window.DealtDamage source damageEffect (toTarget a) damageAmount
-        Lifted.checkAfter $ Window.DealtDamage source damageEffect (toTarget a) damageAmount
-        Lifted.checkWhen $ Window.TakeDamage source damageEffect (toTarget a) damageAmount
-        push $ EnemyDamaged eid damageAssignment
-        Lifted.checkAfter $ Window.TakeDamage source damageEffect (toTarget a) damageAmount
+      let source = damageAssignmentSource damageAssignment
+      case enemyPlacement of
+        AsSwarm {} -> do
+          let
+            damageEffect = damageAssignmentDamageEffect damageAssignment
+            damageAmount = damageAssignmentAmount damageAssignment
+          canDamage <- sourceCanDamageEnemy eid source
+          when canDamage do
+            Lifted.checkWhen $ Window.WouldTakeDamage source (toTarget a) damageAmount DamageDirect
+            Lifted.checkWhen $ Window.DealtDamage source damageEffect (toTarget a) damageAmount
+            Lifted.checkAfter $ Window.DealtDamage source damageEffect (toTarget a) damageAmount
+            Lifted.checkWhen $ Window.TakeDamage source damageEffect (toTarget a) damageAmount
+            push $ EnemyDamaged eid damageAssignment
+            Lifted.checkAfter $ Window.TakeDamage source damageEffect (toTarget a) damageAmount
+        _ -> do
+          swarms <- select $ InPlayEnemy $ SwarmOf eid
+          case swarms of
+            swarm : _ -> push $ Msg.EnemyDamage swarm damageAssignment
+            [] -> do
+              let
+                damageEffect = damageAssignmentDamageEffect damageAssignment
+                damageAmount = damageAssignmentAmount damageAssignment
+              canDamage <- sourceCanDamageEnemy eid source
+              when canDamage do
+                Lifted.checkWhen $ Window.WouldTakeDamage source (toTarget a) damageAmount DamageDirect
+                Lifted.checkWhen $ Window.DealtDamage source damageEffect (toTarget a) damageAmount
+                Lifted.checkAfter $ Window.DealtDamage source damageEffect (toTarget a) damageAmount
+                Lifted.checkWhen $ Window.TakeDamage source damageEffect (toTarget a) damageAmount
+                push $ EnemyDamaged eid damageAssignment
+                Lifted.checkAfter $ Window.TakeDamage source damageEffect (toTarget a) damageAmount
       pure a
     EnemyDamaged eid damageAssignment'' | eid == enemyId -> do
       let source = damageAssignment''.source


### PR DESCRIPTION
Title:
Fix swarming enemy host damage resolution when targeting Swarm of Spiders with Stir the Pot

Issue ID: 3994
https://github.com/halogenandtoast/ArkhamHorror/issues/3994

Summary:
This fixes damage resolution against swarming enemies so damage assigned to a swarming host is routed to one of its swarm cards first, instead of accumulating directly on the face-up host while swarm cards remain.

Problem:
In the failing `Stir the Pot` case, targeting the face-up `Swarm of Spiders` host applied damage directly to the host enemy even though it still had swarm cards underneath it.

That caused two incorrect outcomes:

the swarm card that should have been defeated remained in play
the face-up host could continue accumulating damage and be selected again, even though that damage should have been absorbed by remaining swarm cards first

In the captured game state, this showed up as the host receiving damage while a remaining `AsSwarm` child was still attached, which left the swarming stack in an invalid state.

Change:

Updated `EnemyDamage` handling in `Enemy.Runner`
When the target is a non-swarm host and it still has in-play `SwarmOf eid` children, damage is now redirected to a swarm card instead of being applied to the host
Left direct damage handling unchanged for enemies whose placement is already `AsSwarm`
Kept the existing defeat and excess-damage flow intact after damage reaches the swarm card

Implementation references:
This change works with the existing swarming defeat rules already in:

`CheckDefeated`, which prevents a swarming host from being defeated while swarm cards remain
`EnemyDefeated` / `Discard`, which already clean up swarm defeat state once an actual swarm card is defeated

Files changed:

backend/arkham-api/library/Arkham/Enemy/Runner.hs

Test coverage:
No automated regression spec added in this change.

Validated manually against the provided game state for:

targeting the face-up `Swarm of Spiders` host no longer stacking damage directly on the host while swarm cards remain
damage being routed into a swarm card first
preventing the host from reaching an invalid multi-damage state before swarm cards are removed

Result:

<img width="901" height="442" alt="Screenshot 2026-04-01 at 3 03 55 PM" src="https://github.com/user-attachments/assets/9b0b391c-6dfc-4a7b-8a21-53446b8a9187" />

Now the 2 damages to each enemy are correctly assigned, and the two "swarming 2" spiders only have their host card remaining on the board after the full damages are applied. 

P.S. I shall stop my bug-fixing process until the previous ones are reviewed. @halogenandtoast please let me know if such PRs could be actually beneficial for the project.