### PR TITLE
fix SecondSight5 charge cost logic

### DIFF
--- a/backend/arkham-api/library/Arkham/Asset/Assets/SecondSight5.hs
+++ b/backend/arkham-api/library/Arkham/Asset/Assets/SecondSight5.hs
@@ -4,9 +4,12 @@ import Arkham.Ability
 import Arkham.Asset.Cards qualified as Cards
 import Arkham.Asset.Import.Lifted
 import Arkham.Asset.Uses
+import Arkham.Discover
 import Arkham.ForMovement
+import Arkham.Helpers.Investigator (getJustLocation)
 import Arkham.Helpers.SkillTest.Lifted
 import Arkham.Matcher
+import Arkham.Message qualified as Msg
 import Arkham.Modifier
 
 newtype SecondSight5 = SecondSight5 AssetAttrs
@@ -37,13 +40,19 @@ instance RunMessage SecondSight5 where
       pure a
     PassedThisSkillTest iid (isAbilitySource attrs 1 -> True) -> do
       when (attrs.use #charge > 0) do
-        additionalSkillTestOption "Second Sight (5)" do
-          removeTokens (attrs.ability 1) attrs Charge 1
-          discoverAtMatchingLocation
-            NotInvestigate
-            iid
-            (attrs.ability 1)
-            (orConnected NotForMovement $ locationWithInvestigator iid)
-            1
+        chooseOne iid
+          $ Label "Spend 1 charge to discover 1 additional clue" [DoStep 2 msg]
+          : [Label "Do not spend charge" []]
+      pure a
+    DoStep 2 (PassedThisSkillTest iid (isAbilitySource attrs 1 -> True)) -> do
+      currentLocation <- getJustLocation iid
+      connectedLocations <- select $ ConnectedTo NotForMovement (LocationWithInvestigator $ InvestigatorWithId iid)
+      currentLocationDiscovery <- discover currentLocation (attrs.ability 1) 1
+      connectedLocationDiscoveries <- for connectedLocations \loc -> do
+        d <- discover loc (attrs.ability 1) 1
+        pure (loc, d)
+      chooseOne iid
+        $ targetLabel currentLocation [RemoveTokens (toSource attrs) (toTarget attrs) Charge 1, Msg.DiscoverClues iid currentLocationDiscovery]
+        : map (\(loc, d) -> targetLabel loc [RemoveTokens (toSource attrs) (toTarget attrs) Charge 1, Msg.DiscoverClues iid d]) connectedLocationDiscoveries
       pure a
     _ -> SecondSight5 <$> liftRunMessage msg attrs

--- a/backend/arkham-api/library/Arkham/Asset/Assets/SecondSight5.hs
+++ b/backend/arkham-api/library/Arkham/Asset/Assets/SecondSight5.hs
@@ -4,12 +4,10 @@ import Arkham.Ability
 import Arkham.Asset.Cards qualified as Cards
 import Arkham.Asset.Import.Lifted
 import Arkham.Asset.Uses
-import Arkham.Discover
-import Arkham.ForMovement
-import Arkham.Helpers.Investigator (getJustLocation)
 import Arkham.Helpers.SkillTest.Lifted
 import Arkham.Matcher
-import Arkham.Message qualified as Msg
+import Arkham.Message (optionWhenExists)
+import Arkham.Message.Lifted.Choose
 import Arkham.Modifier
 
 newtype SecondSight5 = SecondSight5 AssetAttrs
@@ -20,8 +18,7 @@ secondSight5 :: AssetCard SecondSight5
 secondSight5 = asset SecondSight5 Cards.secondSight5
 
 instance HasAbilities SecondSight5 where
-  getAbilities (SecondSight5 a) =
-    [skillTestAbility $ controlled_ a 1 $ investigateActionWith_ #willpower]
+  getAbilities (SecondSight5 a) = [skillTestAbility $ controlled_ a 1 $ investigateActionWith_ #willpower]
 
 instance RunMessage SecondSight5 where
   runMessage msg a@(SecondSight5 attrs) = runQueueT $ case msg of
@@ -39,20 +36,19 @@ instance RunMessage SecondSight5 where
         else removeTokens (attrs.ability 1) attrs Charge 1
       pure a
     PassedThisSkillTest iid (isAbilitySource attrs 1 -> True) -> do
-      when (attrs.use #charge > 0) do
-        chooseOne iid
-          $ Label "Spend 1 charge to discover 1 additional clue" [DoStep 2 msg]
-          : [Label "Do not spend charge" []]
+      additionalSkillTestOptionEdit
+        ( setOptionCriteria
+            $ exists (orConnected_ (locationWithInvestigator iid) <> locationWithDiscoverableCluesBy iid)
+            <> thisExists attrs (AssetWithSpendableUses (atLeast 1) Charge)
+        )
+        "Second Sight (5)"
+        do
+          chooseOneM iid do
+            labeled "Spend 1 charge to discover 1 additional clue" $ doStep 2 msg
+            labeled "Do not spend charge" nothing
       pure a
     DoStep 2 (PassedThisSkillTest iid (isAbilitySource attrs 1 -> True)) -> do
-      currentLocation <- getJustLocation iid
-      connectedLocations <- select $ ConnectedTo NotForMovement (LocationWithInvestigator $ InvestigatorWithId iid)
-      currentLocationDiscovery <- discover currentLocation (attrs.ability 1) 1
-      connectedLocationDiscoveries <- for connectedLocations \loc -> do
-        d <- discover loc (attrs.ability 1) 1
-        pure (loc, d)
-      chooseOne iid
-        $ targetLabel currentLocation [RemoveTokens (toSource attrs) (toTarget attrs) Charge 1, Msg.DiscoverClues iid currentLocationDiscovery]
-        : map (\(loc, d) -> targetLabel loc [RemoveTokens (toSource attrs) (toTarget attrs) Charge 1, Msg.DiscoverClues iid d]) connectedLocationDiscoveries
+      spendUses (attrs.ability 1) attrs Charge 1
+      discoverAtMatchingLocation_ iid (attrs.ability 1) (orConnected_ $ locationWithInvestigator iid) 1
       pure a
     _ -> SecondSight5 <$> liftRunMessage msg attrs

--- a/backend/arkham-api/library/Arkham/Message/Lifted.hs
+++ b/backend/arkham-api/library/Arkham/Message/Lifted.hs
@@ -2978,6 +2978,15 @@ discoverAtMatchingLocation isInvestigate iid s mtchr n = do
       | location <- locations
       ]
 
+discoverAtMatchingLocation_
+  :: (ReverseQueue m, Sourceable source)
+  => InvestigatorId
+  -> source
+  -> LocationMatcher
+  -> Int
+  -> m ()
+discoverAtMatchingLocation_ = discoverAtMatchingLocation NotInvestigate
+
 discoverAt
   :: (ReverseQueue m, Sourceable source, AsId a, IdOf a ~ LocationId)
   => IsInvestigate


### PR DESCRIPTION
SecondSight5 should prompt the player to confirm spending 1 charge before applying the additional clue discovery effect.

_If you succeed, you may spend 1 charge to discover 1 additional clue at your location or 1 clue at a connecting location._ 