### PR TITLE
Fix three `start.sh` issues for offline distribution.

### DIFF
--- a/offline/scripts/05-package.sh
+++ b/offline/scripts/05-package.sh
@@ -164,6 +164,39 @@ configure_runtime_env() {
         Linux)  export LD_LIBRARY_PATH="$SCRIPT_DIR/lib:$SCRIPT_DIR/pgsql/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" ;;
         Darwin) export DYLD_LIBRARY_PATH="$SCRIPT_DIR/lib:$SCRIPT_DIR/pgsql/lib${DYLD_LIBRARY_PATH:+:$DYLD_LIBRARY_PATH}" ;;
     esac
+
+    # Fix library symlinks: Windows extraction (zip/tar) often destroys symlinks,
+    # turning them into copies or broken files. Recreate the expected versioned symlinks.
+    _fix_lib_symlinks "$SCRIPT_DIR/pgsql/lib"
+    _fix_lib_symlinks "$SCRIPT_DIR/lib"
+}
+
+# Scan a directory for versioned .so files (lib*.so.X.Y) and recreate short symlinks:
+#   lib*.so.X.Y  →  lib*.so   and  lib*.so.X
+_fix_lib_symlinks() {
+    local dir="$1"
+    [ -d "$dir" ] || return 0
+    local f basename linkname
+    # Match files like libfoo.so.3.14 (major.minor)
+    for f in "$dir"/lib*.so.*.*; do
+        [ -f "$f" ] || continue
+        basename="$(basename "$f")"
+        # e.g. libpq.so.5.14 → derive libpq.so.5 and libpq.so
+        local soname="${basename%.*}"      # libpq.so.5
+        local bare="${soname%.*}"          # libpq.so  (strip .5) — but only if what remains ends with .so
+        # Recreate the soname symlink (libpq.so.5 -> libpq.so.5.14)
+        linkname="$dir/$soname"
+        if [ ! -L "$linkname" ] || [ "$(readlink "$linkname")" != "$basename" ]; then
+            ln -sf "$basename" "$linkname"
+        fi
+        # Recreate the bare symlink (libpq.so -> libpq.so.5.14) only if soname looks like lib*.so.N
+        if [[ "$bare" == *.so ]]; then
+            linkname="$dir/$bare"
+            if [ ! -L "$linkname" ] || [ "$(readlink "$linkname")" != "$basename" ]; then
+                ln -sf "$basename" "$linkname"
+            fi
+        fi
+    done
 }
 
 # ── macOS Gatekeeper: ad-hoc sign all binaries and clear quarantine ───────────
@@ -364,6 +397,9 @@ http {
   keepalive_timeout 65;
   client_body_temp_path $DATA_DIR/nginx_temp;
   proxy_temp_path       $DATA_DIR/nginx_temp;
+  fastcgi_temp_path     $DATA_DIR/nginx_temp;
+  scgi_temp_path        $DATA_DIR/nginx_temp;
+  uwsgi_temp_path       $DATA_DIR/nginx_temp;
   map \$http_upgrade \$connection_upgrade { default upgrade; '' close; }
   server {
     listen $NGINX_PORT;
@@ -464,7 +500,7 @@ do_stop() {
         info "Backing up database ..."
         if ! rm -rf "$PGDATA_LOCAL" 2>/dev/null; then
             warn "[4005] pgdata backup failed: unable to remove old backup"
-        elif ! cp -a "$PG_DATA" "$PGDATA_LOCAL"; then
+        elif ! cp -a "$PG_DATA" "$PGDATA_LOCAL" 2>/dev/null && ! cp -r "$PG_DATA" "$PGDATA_LOCAL"; then
             warn "[4005] pgdata backup failed: copy error"
         else
             date +%s > "$VERSION_FILE"


### PR DESCRIPTION
Hi @halogenandtoast 

This PR fixed the following issues with the `start.sh` script in the offline release distribution:

1. Some Windows users experienced missing symbolic links after extraction, causing `start.sh` to fail to locate the corresponding dynamic libraries upon startup. This issue was resolved by forcing the dynamic libraries to be linked each time `start.sh` runs.

2. Added several temporary directory configurations required for Nginx startup.

3. When using `cp -a` to back up Postgres user data from `WSL/Ubuntu` to the native Windows directory, metadata loss resulted in excessive log output. This was changed to using `cp -r`, as metadata loss with `-a` is not an issue in this context.