### PR TITLE
build(offline): Always compile Nginx from source to remove unnecessary modules

### DIFF
--- a/offline/scripts/01-check-project-deps.sh
+++ b/offline/scripts/01-check-project-deps.sh
@@ -357,28 +357,8 @@ install_nginx() {
         return 0
     fi
 
-    # Try the system-installed nginx first
-    local system_nginx=""
-    for path in /usr/sbin/nginx /usr/local/sbin/nginx /opt/homebrew/bin/nginx; do
-        if [ -x "$path" ]; then
-            system_nginx="$path"
-            break
-        fi
-    done
-    [ -z "$system_nginx" ] && has_cmd "nginx" && system_nginx="$(command -v nginx)"
-
-    if [ -n "$system_nginx" ]; then
-        info "Using system nginx: $system_nginx"
-        ensure_dir "$(dirname "$nginx_bin")"
-        cp "$system_nginx" "$nginx_bin"
-        chmod +x "$nginx_bin"
-        verify_cmd "Nginx" "$nginx_bin" "-v"
-        touch "$STAMP_NGINX"
-        return 0
-    fi
-
     # Build from source (minimal build, keep only HTTP core + proxy modules)
-    info "System nginx not found; building from source (about 2-3 minutes) ..."
+    info "Building nginx from source (about 2-3 minutes) ..."
     local ngx_archive="nginx-${NGINX_VERSION}.tar.gz"
     local ngx_url="https://nginx.org/download/${ngx_archive}"
     local ngx_path; ngx_path="$(download_cached "$ngx_url" "$ngx_archive")"

--- a/offline/scripts/05-package.sh
+++ b/offline/scripts/05-package.sh
@@ -397,9 +397,6 @@ http {
   keepalive_timeout 65;
   client_body_temp_path $DATA_DIR/nginx_temp;
   proxy_temp_path       $DATA_DIR/nginx_temp;
-  fastcgi_temp_path     $DATA_DIR/nginx_temp;
-  scgi_temp_path        $DATA_DIR/nginx_temp;
-  uwsgi_temp_path       $DATA_DIR/nginx_temp;
   map \$http_upgrade \$connection_upgrade { default upgrade; '' close; }
   server {
     listen $NGINX_PORT;

--- a/offline/scripts/05-package.sh
+++ b/offline/scripts/05-package.sh
@@ -164,6 +164,39 @@ configure_runtime_env() {
         Linux)  export LD_LIBRARY_PATH="$SCRIPT_DIR/lib:$SCRIPT_DIR/pgsql/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" ;;
         Darwin) export DYLD_LIBRARY_PATH="$SCRIPT_DIR/lib:$SCRIPT_DIR/pgsql/lib${DYLD_LIBRARY_PATH:+:$DYLD_LIBRARY_PATH}" ;;
     esac
+
+    # Fix library symlinks: Windows extraction (zip/tar) often destroys symlinks,
+    # turning them into copies or broken files. Recreate the expected versioned symlinks.
+    _fix_lib_symlinks "$SCRIPT_DIR/pgsql/lib"
+    _fix_lib_symlinks "$SCRIPT_DIR/lib"
+}
+
+# Scan a directory for versioned .so files (lib*.so.X.Y) and recreate short symlinks:
+#   lib*.so.X.Y  →  lib*.so   and  lib*.so.X
+_fix_lib_symlinks() {
+    local dir="$1"
+    [ -d "$dir" ] || return 0
+    local f basename linkname
+    # Match files like libfoo.so.3.14 (major.minor)
+    for f in "$dir"/lib*.so.*.*; do
+        [ -f "$f" ] || continue
+        basename="$(basename "$f")"
+        # e.g. libpq.so.5.14 → derive libpq.so.5 and libpq.so
+        local soname="${basename%.*}"      # libpq.so.5
+        local bare="${soname%.*}"          # libpq.so  (strip .5) — but only if what remains ends with .so
+        # Recreate the soname symlink (libpq.so.5 -> libpq.so.5.14)
+        linkname="$dir/$soname"
+        if [ ! -L "$linkname" ] || [ "$(readlink "$linkname")" != "$basename" ]; then
+            ln -sf "$basename" "$linkname"
+        fi
+        # Recreate the bare symlink (libpq.so -> libpq.so.5.14) only if soname looks like lib*.so.N
+        if [[ "$bare" == *.so ]]; then
+            linkname="$dir/$bare"
+            if [ ! -L "$linkname" ] || [ "$(readlink "$linkname")" != "$basename" ]; then
+                ln -sf "$basename" "$linkname"
+            fi
+        fi
+    done
 }
 
 # ── macOS Gatekeeper: ad-hoc sign all binaries and clear quarantine ───────────
@@ -364,6 +397,9 @@ http {
   keepalive_timeout 65;
   client_body_temp_path $DATA_DIR/nginx_temp;
   proxy_temp_path       $DATA_DIR/nginx_temp;
+  fastcgi_temp_path     $DATA_DIR/nginx_temp;
+  scgi_temp_path        $DATA_DIR/nginx_temp;
+  uwsgi_temp_path       $DATA_DIR/nginx_temp;
   map \$http_upgrade \$connection_upgrade { default upgrade; '' close; }
   server {
     listen $NGINX_PORT;
@@ -464,7 +500,7 @@ do_stop() {
         info "Backing up database ..."
         if ! rm -rf "$PGDATA_LOCAL" 2>/dev/null; then
             warn "[4005] pgdata backup failed: unable to remove old backup"
-        elif ! cp -a "$PG_DATA" "$PGDATA_LOCAL"; then
+        elif ! cp -a "$PG_DATA" "$PGDATA_LOCAL" 2>/dev/null && ! cp -r "$PG_DATA" "$PGDATA_LOCAL"; then
             warn "[4005] pgdata backup failed: copy error"
         else
             date +%s > "$VERSION_FILE"


### PR DESCRIPTION
Just for reduce the size of the offline release package.

No longer prioritize checking for and using the system Nginx,
even though this would speed up the compilation process.