### PR TITLE
Allow shuffling into empty decks

### DIFF
--- a/backend/arkham-api/arkham-api.cabal
+++ b/backend/arkham-api/arkham-api.cabal
@@ -6273,6 +6273,7 @@ test-suite spec
       Arkham.Event.Events.WillToSurvive3Spec
       Arkham.Event.Events.WorkingAHunchSpec
       Arkham.GameSpec
+      Arkham.Helpers.ShuffleSpec
       Arkham.Investigator.Cards.AgnesBakerSpec
       Arkham.Investigator.Cards.AshcanPeteSpec
       Arkham.Investigator.Cards.DaisyWalkerSpec

--- a/backend/arkham-api/library/Arkham/Helpers/Shuffle.hs
+++ b/backend/arkham-api/library/Arkham/Helpers/Shuffle.hs
@@ -4,7 +4,6 @@ import Arkham.Capability
 import Arkham.Card
 import Arkham.Classes.HasGame
 import Arkham.Deck qualified as Deck
-import Arkham.Helpers.Deck
 import Arkham.Helpers.Window (DrawnCard)
 import Arkham.Id
 import Arkham.Prelude
@@ -14,7 +13,7 @@ import Arkham.Tracing
 class CanShuffleIn a where
   getCanShuffleIn :: (HasGame m, Tracing m, Deck.IsDeck deck) => deck -> a -> m Bool
   getCanShuffleIn (Deck.toDeck -> deck) _a =
-    andM [not <$> isDeckEmpty deck, maybe (pure True) getCanShuffleDeckX deck.investigator]
+    maybe (pure True) getCanShuffleDeckX deck.investigator
 
 instance CanShuffleIn Card
 instance CanShuffleIn a => CanShuffleIn (Only a)

--- a/backend/arkham-api/library/Arkham/Matcher/Patterns.hs
+++ b/backend/arkham-api/library/Arkham/Matcher/Patterns.hs
@@ -18,9 +18,9 @@ import Arkham.Trait
 
 pattern CanShuffleIn :: InvestigatorMatcher
 pattern CanShuffleIn <-
-  InvestigatorMatches [DeckWith AnyCards, InvestigatorWithoutModifier CannotManipulateDeck]
+  InvestigatorWithoutModifier CannotManipulateDeck
   where
-    CanShuffleIn = InvestigatorMatches [DeckWith AnyCards, InvestigatorWithoutModifier CannotManipulateDeck]
+    CanShuffleIn = InvestigatorWithoutModifier CannotManipulateDeck
 
 pattern AtYourLocation :: InvestigatorMatcher
 pattern AtYourLocation =

--- a/backend/arkham-api/library/Arkham/Message/Lifted.hs
+++ b/backend/arkham-api/library/Arkham/Message/Lifted.hs
@@ -64,6 +64,7 @@ import Arkham.Helpers.Modifiers qualified as Msg
 import Arkham.Helpers.Query
 import Arkham.Helpers.Ref (sourceToTarget)
 import Arkham.Helpers.Scenario (getEncounterDeckKey, getInResolution)
+import Arkham.Helpers.Shuffle
 import Arkham.Helpers.SkillTest qualified as Msg
 import Arkham.Helpers.UI qualified as Msg
 import Arkham.Helpers.Xp
@@ -1890,16 +1891,19 @@ revealingEdit iid (toSource -> source) (toTarget -> target) zone f = Msg.push $ 
 
 
 shuffleCardsIntoTopOfDeck
-  :: (ReverseQueue m, IsDeck deck, MonoFoldable cards, Element cards ~ card, IsCard card)
+  :: ( ReverseQueue m
+     , IsDeck deck
+     , MonoFoldable cards
+     , Element cards ~ card
+     , IsCard card
+     , CanShuffleIn cards
+     )
   => deck
   -> Int
   -> cards
   -> m ()
-shuffleCardsIntoTopOfDeck deck n cards =
-  case length cards of
-    0 -> pure ()
-    1 -> guardPlayerDeckIsNotEmpty deck $ push $ Msg.shuffleCardsIntoTopOfDeck deck n cards
-    _ -> push $ Msg.shuffleCardsIntoTopOfDeck deck n cards
+shuffleCardsIntoTopOfDeck deck n cards = whenCanShuffleIn deck cards do
+  push $ Msg.shuffleCardsIntoTopOfDeck deck n cards
 
 
 reduceCostOf :: (Sourceable source, IsCard card, ReverseQueue m) => source -> card -> Int -> m ()

--- a/backend/arkham-api/library/Arkham/Message/Lifted/Base.hs
+++ b/backend/arkham-api/library/Arkham/Message/Lifted/Base.hs
@@ -33,8 +33,7 @@ import Arkham.Classes.HasQueue hiding (insertAfterMatching)
 import Arkham.Classes.HasQueue as X (runQueueT)
 import Arkham.Classes.Query
 import Arkham.DamageEffect
-import Arkham.Deck (IsDeck (..))
-import Arkham.Deck qualified as Deck
+import Arkham.Deck (IsDeck)
 import Arkham.Discover as X (IsInvestigate (..))
 import Arkham.Discover qualified as Msg
 import Arkham.Draw.Types
@@ -119,19 +118,10 @@ import Arkham.Xp
 import Control.Monad.State.Strict (MonadState, StateT, execStateT, get, put)
 import Control.Monad.Trans.Class
 import Data.Aeson.Key qualified as Aeson
-import Data.Map.Strict qualified as Map
 import Data.Typeable
 
 capture :: MonadIO m => QueueT msg m a -> m [msg]
 capture = evalQueueT
-
-guardPlayerDeckIsNotEmpty :: (HasCallStack, ReverseQueue m, IsDeck deck) => deck -> m () -> m ()
-guardPlayerDeckIsNotEmpty deck body = case toDeck deck of
-  Deck.InvestigatorDeck iid -> whenM (fieldMap InvestigatorDeck (not . null) iid) body
-  Deck.InvestigatorDeckByKey iid deckKey -> do
-    mdeck <- Map.lookup deckKey <$> field InvestigatorDecks iid
-    when (maybe False (not . null) mdeck) body
-  _ -> body
 
 matchingDon't :: (MonadTrans t, HasQueue Message m) => (Message -> Bool) -> t m ()
 matchingDon't f = lift $ popMessageMatching_ f

--- a/backend/arkham-api/library/Arkham/Message/Lifted/Card.hs
+++ b/backend/arkham-api/library/Arkham/Message/Lifted/Card.hs
@@ -166,8 +166,8 @@ shuffleIntoDeck :: (ReverseQueue m, IsDeck deck, Targetable target) => deck -> t
 shuffleIntoDeck deck target = whenCanShuffleIn deck (toTarget target) do
   push $ Msg.shuffleIntoDeck deck target
 
-shuffleDeck :: (ReverseQueue m, IsDeck deck, HasCallStack) => deck -> m ()
-shuffleDeck deck = guardPlayerDeckIsNotEmpty deck $ push $ ShuffleDeck (toDeck deck)
+shuffleDeck :: (ReverseQueue m, IsDeck deck) => deck -> m ()
+shuffleDeck deck = push $ ShuffleDeck (toDeck deck)
 
 don'tAddToVictory :: (MonadTrans t, HasQueue Message m) => EnemyId -> t m ()
 don'tAddToVictory eid = matchingDon't \case

--- a/backend/arkham-api/tests/Arkham/Helpers/ShuffleSpec.hs
+++ b/backend/arkham-api/tests/Arkham/Helpers/ShuffleSpec.hs
@@ -1,0 +1,43 @@
+module Arkham.Helpers.ShuffleSpec (spec) where
+
+import Arkham.Deck qualified as Deck
+import Arkham.Event.Cards qualified as Events
+import Arkham.Helpers.Scenario (scenarioFieldMap)
+import Arkham.Location.Cards qualified as Locations
+import Arkham.Matcher
+import Arkham.Message.Lifted qualified as Lifted
+import Arkham.Scenario.Deck
+import Arkham.Scenario.Types (Field (..))
+import Data.Map.Strict qualified as Map
+import TestImport.New
+
+spec :: Spec
+spec = describe "shuffleCardsIntoDeck" do
+  it "matches investigators who can shuffle into an empty deck" . gameTest $ \self -> do
+    selectAny (InvestigatorWithId self.id <> CanShuffleIn) `shouldReturn` True
+
+  it "can shuffle a single card into an empty scenario deck" . gameTest $ \_ -> do
+    chamberOfTime <- genCard Locations.chamberOfTime
+
+    Lifted.runQueueT $ Lifted.shuffleCardsIntoDeck ExplorationDeck (only chamberOfTime)
+    runMessages
+
+    scenarioFieldMap ScenarioDecks (Map.lookup ExplorationDeck) `shouldReturn` Just [chamberOfTime]
+
+  it "does not shuffle an empty card list into a scenario deck" . gameTest $ \_ -> do
+    Lifted.runQueueT $ Lifted.shuffleCardsIntoDeck ExplorationDeck ([] :: [Card])
+    runMessages
+
+    scenarioFieldMap ScenarioDecks (Map.lookup ExplorationDeck) `shouldReturn` Nothing
+
+  it "queues shuffling an empty investigator deck" . gameTest $ \self -> do
+    messages <- Lifted.capture $ Lifted.shuffleDeck self.id
+
+    messages `shouldBe` [ShuffleDeck (Deck.InvestigatorDeck self.id)]
+
+  it "queues shuffling cards into the top of an empty investigator deck" . gameTest $ \self -> do
+    emergencyCache <- genCard Events.emergencyCache
+
+    messages <- Lifted.capture $ Lifted.shuffleCardsIntoTopOfDeck self.id 1 [emergencyCache]
+
+    messages `shouldBe` [ShuffleCardsIntoTopOfDeck (Deck.InvestigatorDeck self.id) 1 [emergencyCache]]


### PR DESCRIPTION
## Summary

Fix shuffle helpers so an empty destination deck is still a valid shuffle target.

This fixes scenarios where an act or agenda advances and needs to shuffle a set-aside card into a scenario deck that may already be empty, such as adding Chamber of Time to the exploration deck.

## Root cause

The shuffle guard conflated two concerns:

- whether there are cards to shuffle
- whether the destination deck currently has cards

An empty destination deck is valid. Empty input should still be a no-op, and investigator deck manipulation restrictions should still apply.

## Changes

- Remove the destination deck non-empty check from `CanShuffleIn`.
- Align the `CanShuffleIn` investigator matcher with the same semantics.
- Remove `guardPlayerDeckIsNotEmpty`.
- Route `shuffleCardsIntoTopOfDeck` through `whenCanShuffleIn`.
- Let `shuffleDeck` enqueue directly; shuffling an empty deck is a valid no-op at the runner boundary.
- Add regression tests for empty scenario decks, empty input, empty investigator decks, and matcher behavior.

## Validation

```sh
stack test arkham-api:spec --test-arguments='--match /shuffleCardsIntoDeck/'
```

Result: `5 examples, 0 failures`.
