### PR TITLE
Fix upgrade deck JSON upload

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,7 @@
     "lint:fix": "eslint src --fix",
     "format": "prettier --write \"src/**/*.{ts,vue}\"",
     "format:check": "prettier --check \"src/**/*.{ts,vue}\"",
+    "test": "node --test tests/**/*.test.mjs",
     "digest": "node ./scripts/digest.cjs",
     "slim-cards": "node ./scripts/slim-cards.cjs"
   },

--- a/frontend/src/arkham/components/UpgradeDeck.vue
+++ b/frontend/src/arkham/components/UpgradeDeck.vue
@@ -11,6 +11,7 @@ import Prompt from '@/components/Prompt.vue';
 import XpBreakdown from '@/arkham/components/XpBreakdown.vue';
 import type { XpBreakdownStep } from '@/arkham/types/Xp';
 import Question from '@/arkham/components/Question.vue';
+import { loadUpgradeDeckFromJsonText } from '@/arkham/upgradeDeckUpload';
 
 // TODO should we pass in the investigator
 export interface Props {
@@ -40,7 +41,6 @@ const investigator = computed(() => {
   })
 })
 const investigatorId = computed(() => !solo && deckInvestigator.value ? `c${deckInvestigator.value}` : investigator.value?.id)
-const investigators = computed(() => Object.values(props.game.investigators))
 const originalInvestigatorId = computed(() => investigator.value?.id)
 const xp = computed(() => {
   const inv = investigator.value
@@ -148,7 +148,7 @@ async function syncUpgrade() {
           } else {
             nextUrl = null;
           }
-        } catch (error) {
+        } catch {
           nextUrl = null;
         }
       } while (nextUrl);
@@ -180,7 +180,7 @@ async function syncUpgrade() {
           } else {
             nextUrl = null;
           }
-        } catch (error) {
+        } catch {
           nextUrl = null;
         }
       } while (nextUrl);
@@ -243,16 +243,14 @@ function loadDeckFromFile(e: Event) {
   const reader = new FileReader()
   reader.onloadend = (e1: ProgressEvent<FileReader>) => {
     if (!e1?.target?.result) return
-    try {
-      const data = JSON.parse(e1.target.result.toString()) as ArkhamDbDecklist
-      model.value = data
-      deckList.value = data
-      deckUrl.value = data.url ?? null
-      deck.value = data.url ?? null
-      deckInvestigator.value = data.investigator_code
-    } catch {
-      // ignore invalid json
-    }
+    loadUpgradeDeckFromJsonText(e1.target.result.toString(), {
+      setModel: (data) => { model.value = data },
+      setDeckList: (data) => { deckList.value = data },
+      setDeckUrl: (url) => { deckUrl.value = url },
+      setDeck: (url) => { deck.value = url },
+      setDeckInvestigator: (investigatorCode) => { deckInvestigator.value = investigatorCode },
+      upgrade,
+    })
   }
   reader.readAsText(file)
   ;(e.target as HTMLInputElement).value = ''

--- a/frontend/src/arkham/upgradeDeckUpload.ts
+++ b/frontend/src/arkham/upgradeDeckUpload.ts
@@ -1,0 +1,43 @@
+import type { ArkhamDbDecklist } from '@/arkham/types/Deck'
+
+export interface UpgradeDeckUploadActions {
+  setModel: (deck: ArkhamDbDecklist) => void
+  setDeckList: (deck: ArkhamDbDecklist) => void
+  setDeckUrl: (url: string | null) => void
+  setDeck: (url: string | null) => void
+  setDeckInvestigator: (investigatorCode: string) => void
+  upgrade: () => void
+}
+
+function isUploadableUpgradeDeck(data: unknown): data is ArkhamDbDecklist {
+  return (
+    typeof data === 'object' &&
+    data !== null &&
+    'investigator_code' in data &&
+    typeof data.investigator_code === 'string' &&
+    data.investigator_code.length > 0
+  )
+}
+
+export function loadUpgradeDeckFromJsonText(
+  jsonText: string,
+  actions: UpgradeDeckUploadActions,
+): boolean {
+  try {
+    const data = JSON.parse(jsonText) as unknown
+    if (!isUploadableUpgradeDeck(data)) return false
+
+    const deckUrl = data.url ?? null
+
+    actions.setModel(data)
+    actions.setDeckList(data)
+    actions.setDeckUrl(deckUrl)
+    actions.setDeck(deckUrl)
+    actions.setDeckInvestigator(data.investigator_code)
+    actions.upgrade()
+
+    return true
+  } catch {
+    return false
+  }
+}

--- a/frontend/src/arkham/upgradeDeckUpload.ts
+++ b/frontend/src/arkham/upgradeDeckUpload.ts
@@ -10,13 +10,20 @@ export interface UpgradeDeckUploadActions {
 }
 
 function isUploadableUpgradeDeck(data: unknown): data is ArkhamDbDecklist {
-  return (
-    typeof data === 'object' &&
-    data !== null &&
-    'investigator_code' in data &&
-    typeof data.investigator_code === 'string' &&
-    data.investigator_code.length > 0
-  )
+  if (typeof data !== 'object' || data === null || Array.isArray(data)) return false
+  const d = data as Record<string, unknown>
+
+  if (typeof d.id !== 'string') return false
+  if (typeof d.name !== 'string') return false
+  if (typeof d.investigator_name !== 'string') return false
+  if (typeof d.investigator_code !== 'string' || d.investigator_code.length === 0) return false
+
+  if (!('url' in d) || (d.url !== null && typeof d.url !== 'string')) return false
+
+  if (typeof d.slots !== 'object' || d.slots === null || Array.isArray(d.slots)) return false
+  if (!Object.values(d.slots as Record<string, unknown>).every((v) => typeof v === 'number')) return false
+
+  return true
 }
 
 export function loadUpgradeDeckFromJsonText(

--- a/frontend/tests/upgradeDeckUpload.test.mjs
+++ b/frontend/tests/upgradeDeckUpload.test.mjs
@@ -1,0 +1,93 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import { resolve } from 'node:path'
+import test from 'node:test'
+import ts from 'typescript'
+
+async function importTsModule(path) {
+  const source = await readFile(path, 'utf8')
+  const { outputText } = ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.ES2022,
+      target: ts.ScriptTarget.ES2022,
+      verbatimModuleSyntax: true,
+    },
+    fileName: path,
+  })
+
+  return import(`data:text/javascript;base64,${Buffer.from(outputText).toString('base64')}`)
+}
+
+const modulePath = resolve('src/arkham/upgradeDeckUpload.ts')
+
+test('uploaded upgrade deck JSON is applied and submitted', async () => {
+  const { loadUpgradeDeckFromJsonText } = await importTsModule(modulePath)
+  const deck = {
+    id: '6454',
+    url: 'https://arkhamdb.com/api/public/deck/6454',
+    name: 'Roland upgrade',
+    investigator_code: '1001',
+    investigator_name: 'Roland Banks',
+    slots: { '01016': 1 },
+  }
+  const calls = []
+
+  const loaded = loadUpgradeDeckFromJsonText(JSON.stringify(deck), {
+    setModel: (value) => calls.push(['model', value]),
+    setDeckList: (value) => calls.push(['deckList', value]),
+    setDeckUrl: (value) => calls.push(['deckUrl', value]),
+    setDeck: (value) => calls.push(['deck', value]),
+    setDeckInvestigator: (value) => calls.push(['deckInvestigator', value]),
+    upgrade: () => calls.push(['upgrade']),
+  })
+
+  assert.equal(loaded, true)
+  assert.deepEqual(
+    calls.map(([name]) => name),
+    ['model', 'deckList', 'deckUrl', 'deck', 'deckInvestigator', 'upgrade'],
+  )
+  assert.deepEqual(calls[1][1], deck)
+  assert.equal(calls[2][1], deck.url)
+  assert.equal(calls[4][1], deck.investigator_code)
+})
+
+test('invalid uploaded upgrade deck JSON is ignored', async () => {
+  const { loadUpgradeDeckFromJsonText } = await importTsModule(modulePath)
+  const calls = []
+
+  const loaded = loadUpgradeDeckFromJsonText('{', {
+    setModel: (value) => calls.push(['model', value]),
+    setDeckList: (value) => calls.push(['deckList', value]),
+    setDeckUrl: (value) => calls.push(['deckUrl', value]),
+    setDeck: (value) => calls.push(['deck', value]),
+    setDeckInvestigator: (value) => calls.push(['deckInvestigator', value]),
+    upgrade: () => calls.push(['upgrade']),
+  })
+
+  assert.equal(loaded, false)
+  assert.deepEqual(calls, [])
+})
+
+test('uploaded upgrade deck JSON without investigator code is ignored', async () => {
+  const { loadUpgradeDeckFromJsonText } = await importTsModule(modulePath)
+  const calls = []
+  const deck = {
+    id: '6454',
+    url: 'https://arkhamdb.com/api/public/deck/6454',
+    name: 'Roland upgrade',
+    investigator_name: 'Roland Banks',
+    slots: { '01016': 1 },
+  }
+
+  const loaded = loadUpgradeDeckFromJsonText(JSON.stringify(deck), {
+    setModel: (value) => calls.push(['model', value]),
+    setDeckList: (value) => calls.push(['deckList', value]),
+    setDeckUrl: (value) => calls.push(['deckUrl', value]),
+    setDeck: (value) => calls.push(['deck', value]),
+    setDeckInvestigator: (value) => calls.push(['deckInvestigator', value]),
+    upgrade: () => calls.push(['upgrade']),
+  })
+
+  assert.equal(loaded, false)
+  assert.deepEqual(calls, [])
+})


### PR DESCRIPTION
## Summary
- Fix the upgrade deck page JSON upload path so a valid uploaded deck is applied and submitted immediately.
- Extract the upload JSON handling into a pure helper with runtime validation for required deck data.
- Add node:test coverage for successful upload, invalid JSON, and missing `investigator_code`.

## Test Plan
- `cd frontend && npm test`
- `cd frontend && npm run tc`
- `cd frontend && npm run lint` (passes with existing warnings)
