### PR TITLE
Apply in-hand card effects to cards that are as-if-in-hand for play

### DIFF
--- a/backend/arkham-api/arkham-api.cabal
+++ b/backend/arkham-api/arkham-api.cabal
@@ -6871,6 +6871,7 @@ test-suite spec
       Arkham.Asset.Assets.OldBookOfLoreSpec
       Arkham.Asset.Assets.OnTheirHeels5Spec
       Arkham.Asset.Assets.PatricesViolinSpec
+      Arkham.Asset.Assets.PeltShipmentSpec
       Arkham.Asset.Assets.PendantOfTheQueenSpec
       Arkham.Asset.Assets.PeterSylvestreSpec
       Arkham.Asset.Assets.PhysicalTraining2Spec
@@ -6941,6 +6942,7 @@ test-suite spec
       Arkham.Event.Events.LookWhatIFoundSpec
       Arkham.Event.Events.Lucky2Spec
       Arkham.Event.Events.LuckySpec
+      Arkham.Event.Events.Marksmanship1Spec
       Arkham.Event.Events.MindOverMatterSpec
       Arkham.Event.Events.MindWipe1Spec
       Arkham.Event.Events.OccultEvidenceSpec

--- a/backend/arkham-api/library/Arkham/Game/Runner.hs
+++ b/backend/arkham-api/library/Arkham/Game/Runner.hs
@@ -106,7 +106,7 @@ import Arkham.Matcher hiding (
 import Arkham.Message qualified as Msg
 import Arkham.Message.Lifted (removeLocation)
 import Arkham.Message.Lifted qualified as Lifted
-import Arkham.Modifier (Modifier (modifierSource, modifierType))
+import Arkham.Modifier (Modifier (Modifier, modifierSource, modifierType), ModifierType (AsIfInHandFor))
 import Arkham.Movement
 import Arkham.Name
 import Arkham.Phase
@@ -3563,9 +3563,23 @@ preloadEntities g = do
       | Just Refl <- eqT @a @Treachery = overAttrs (\attrs -> attrs {treacheryPlacement = p}) a
       | otherwise = a
     preloadHandEntities entities investigator' = do
-      asIfInHandCards <- getAsIfInHandCardsFor NotForPlay (toId investigator')
-      committedCards <- field Investigator.InvestigatorCommittedCards (toId investigator')
+      let iid = toId investigator'
+      asIfInHandCards <- getAsIfInHandEffectCards iid
+      committedCards <- field Investigator.InvestigatorCommittedCards iid
+      -- Cards that are only "as if in hand for play" (stashed under Backpack /
+      -- Stick to the Plan, etc.) physically sit under their host asset, not in
+      -- hand. Load their entity at the host's placement rather than StillInHand,
+      -- so "while in your hand" effects (e.g. Pelt Shipment's hand-size penalty)
+      -- don't fire while the card is merely playable from under the asset.
+      forPlayMods <- getModifiers' (InvestigatorTarget iid)
       let
+        forPlayHosts :: Map CardId AssetId
+        forPlayHosts =
+          mapFromList
+            [ (cid, aid)
+            | Modifier {modifierType = AsIfInHandFor ForPlay cid, modifierSource = AssetSource aid} <- forPlayMods
+            ]
+        placementFor c = maybe (StillInHand iid) (`AttachedToAsset` Nothing) (lookup c.id forPlayHosts)
         handEffectCards =
           filter (cdCardInHandEffects . toCardDef)
             $ investigatorHand (toAttrs investigator')
@@ -3579,8 +3593,8 @@ preloadEntities g = do
                 foldl'
                   ( \e c ->
                       addCardEntityWith
-                        (toId investigator')
-                        (setPlacement $ StillInHand investigator'.id)
+                        iid
+                        (setPlacement $ placementFor c)
                         (unsafeCardIdToUUID c.id)
                         e
                         c
@@ -3588,7 +3602,7 @@ preloadEntities g = do
                   defaultEntities
                   handEffectCards
              in
-              insertMap (toId investigator') handEntities entities
+              insertMap iid handEntities entities
     preloadDiscardEntities entities investigator' = do
       -- NOTE: recently added the asset type check here to avoid the "Do
       -- (DiscardCard..." message's action removed entity conflicting with this

--- a/backend/arkham-api/library/Arkham/Helpers/Investigator.hs
+++ b/backend/arkham-api/library/Arkham/Helpers/Investigator.hs
@@ -750,6 +750,23 @@ getAsIfInHandCardsFor forPlay iid = do
       NotForPlay -> []
   pure $ playableFromOutOfHand <> cardsAddedViaModifiers
 
+-- | Cards to load as in-hand effect entities (see 'preloadEntities'). Unlike
+-- 'getAsIfInHandCardsFor', this is agnostic to ForPlay/NotForPlay: a card that
+-- is only "as if in hand for play" (e.g. an event stashed under Stick to the
+-- Plan or Backpack) must still have its in-hand effects ('cdCardInHandEffects')
+-- applied -- otherwise e.g. Marksmanship(1)'s targeting modifier never fires
+-- while it sits under Stick to the Plan. Cards merely playable from
+-- discard/deck are deliberately excluded; those load as their own entities.
+getAsIfInHandEffectCards :: (HasCallStack, HasGame m, Tracing m) => InvestigatorId -> m [Card]
+getAsIfInHandEffectCards iid = do
+  isSkillTest <- isJust <$> getSkillTest
+  modifiers <- getModifiers (InvestigatorTarget iid)
+  flip mapMaybeM modifiers $ \case
+    AsIfInHand c -> pure $ Just c
+    AsIfInHandFor _ c -> Just <$> getCard c
+    CanCommitToSkillTestsAsIfInHand c | isSkillTest -> pure $ Just c
+    _ -> pure Nothing
+
 matchWho
   :: (HasGame m, Tracing m)
   => InvestigatorId

--- a/backend/arkham-api/tests/Arkham/Asset/Assets/PeltShipmentSpec.hs
+++ b/backend/arkham-api/tests/Arkham/Asset/Assets/PeltShipmentSpec.hs
@@ -1,0 +1,24 @@
+module Arkham.Asset.Assets.PeltShipmentSpec (spec) where
+
+import Arkham.Asset.Cards qualified as Assets
+import TestImport.New
+
+-- Pelt Shipment imposes "while in your hand, your hand size is reduced by 3".
+-- That penalty must only apply while the card is *actually* in hand, not while
+-- it is merely "as if in hand for play" under a host asset (e.g. Backpack). The
+-- 45 Automatic is put into play afterwards purely to drive a preload pass so the
+-- stashed card is loaded as an in-hand effect entity.
+spec :: Spec
+spec = describe "Pelt Shipment" do
+  it "reduces max hand size by 3 while actually in hand" . gameTest $ \self -> do
+    peltShipment <- genMyCard self Assets.peltShipment
+    withProp @"hand" [peltShipment] self
+    _ <- self `putAssetIntoPlay` Assets.fortyFiveAutomatic
+    assert $ self `hasModifier` HandSize (-3)
+
+  it "does not reduce hand size while only stashed under Backpack" . gameTest $ \self -> do
+    backpack <- self `putAssetIntoPlay` Assets.backpack
+    peltShipment <- genMyCard self Assets.peltShipment
+    run $ PlaceUnderneath (toTarget backpack) [peltShipment]
+    _ <- self `putAssetIntoPlay` Assets.fortyFiveAutomatic
+    assert $ self `withoutModifier` HandSize (-3)

--- a/backend/arkham-api/tests/Arkham/Event/Events/Marksmanship1Spec.hs
+++ b/backend/arkham-api/tests/Arkham/Event/Events/Marksmanship1Spec.hs
@@ -1,0 +1,62 @@
+module Arkham.Event.Events.Marksmanship1Spec (spec) where
+
+import Arkham.Asset.Cards qualified as Assets
+import Arkham.Event.Cards qualified as Events
+import TestImport.New
+
+-- Marksmanship (1) has an in-hand HasModifiersFor that "opens up" a
+-- Firearm/Ranged fight action to target enemies at a connected location. The
+-- weapon is put into play *after* the event is placed so the next message's
+-- preloadEntities pass picks the event up as an in-hand effect entity.
+spec :: Spec
+spec = describe "Marksmanship (1)" do
+  it "while in hand, lets a Firearm fight an enemy at a connected location"
+    . gameTest
+    $ \self -> do
+      withProp @"combat" 5 self
+      withProp @"resources" 5 self
+      setChaosTokens [Zero]
+
+      (here, there) <- testConnectedLocations id id
+      self `moveTo` here
+      run $ RevealLocation Nothing (toId there)
+      enemy <- testEnemy & prop @"fight" 2 & prop @"health" 5
+      enemy `spawnAt` there
+
+      marksmanship <- genMyCard self Events.marksmanship1
+      withProp @"hand" [marksmanship] self
+      fortyFiveAutomatic <- self `putAssetIntoPlay` Assets.fortyFiveAutomatic
+
+      [doFight] <- self `getActionsFrom` fortyFiveAutomatic
+      self `useAbility` doFight
+      chooseTarget marksmanship -- play Marksmanship from the fight window
+      chooseTarget enemy -- its effect lets the fight target the connected enemy
+      startSkillTest
+      applyResults
+      enemy.damage `shouldReturn` 3
+
+  it "attached under Stick to the Plan (3), still lets a Firearm fight an enemy at a connected location"
+    . gameTest
+    $ \self -> do
+      withProp @"combat" 5 self
+      withProp @"resources" 5 self
+      setChaosTokens [Zero]
+
+      (here, there) <- testConnectedLocations id id
+      self `moveTo` here
+      run $ RevealLocation Nothing (toId there)
+      enemy <- testEnemy & prop @"fight" 2 & prop @"health" 5
+      enemy `spawnAt` there
+
+      stickToThePlan <- self `putAssetIntoPlay` Assets.stickToThePlan3
+      marksmanship <- genMyCard self Events.marksmanship1
+      run $ PlaceUnderneath (toTarget stickToThePlan) [marksmanship]
+      fortyFiveAutomatic <- self `putAssetIntoPlay` Assets.fortyFiveAutomatic
+
+      [doFight] <- self `getActionsFrom` fortyFiveAutomatic
+      self `useAbility` doFight
+      chooseTarget marksmanship -- play Marksmanship from the fight window
+      chooseTarget enemy -- its effect lets the fight target the connected enemy
+      startSkillTest
+      applyResults
+      enemy.damage `shouldReturn` 3


### PR DESCRIPTION
## Problem

Cards with in-hand effects (`cdCardInHandEffects`) were only loaded as in-hand effect entities when literally in hand or marked `AsIfInHandFor NotForPlay`. Cards that are only `AsIfInHandFor ForPlay` — events/assets stashed under **Stick to the Plan**, **Backpack**, etc. — never had their in-hand `HasModifiersFor`/`HasAbilities` collected.

Concretely, **Marksmanship (1)** attached under **Stick to the Plan** could not open up a Firearm fight against an enemy at a connected location, because its in-hand targeting modifier never fired while the card sat under the asset.

## Fix

`preloadHandEntities` now also loads these cards (via a new `getAsIfInHandEffectCards` helper), placing each at its **host's location** (`AttachedToAsset`) rather than `StillInHand`.

A card stashed under a host is only "as if in hand *for play*"; it is not actually in hand. Loading it at the host's placement means "while in your hand" effects keyed on `placement == StillInHand` (e.g. **Pelt Shipment**'s hand-size penalty, **The Tower XVI**'s no-commit) correctly do **not** fire while the card merely sits under the host. Effects keyed on playability (Marksmanship's targeting modifier) are unaffected, since they don't look at placement.

## Tests

- `Marksmanship1Spec`: Marksmanship (1) under Stick to the Plan opens a Firearm fight against a connected-location enemy (and in hand, as a baseline).
- `PeltShipmentSpec`: Pelt Shipment reduces hand size by 3 while actually in hand, but **not** while only stashed under Backpack.

Full backend suite: 525 examples, 0 failures.