### PR TITLE
Fix multi-step undo step trimming

### DIFF
--- a/backend/arkham-api/library/Api/Handler/Arkham/Undo.hs
+++ b/backend/arkham-api/library/Api/Handler/Arkham/Undo.hs
@@ -316,6 +316,12 @@ stepBackToScenarioStep userId gameId rawGame targetStep = runExceptT do
     pure steps
 
   lift do
+    -- The step-deletion trigger only permits deleting steps greater than the
+    -- game's current step. Move the game cursor first, then trim future steps.
+    update \g -> do
+      set g [ArkhamGameStep =. val toStep]
+      where_ $ g.id ==. val gameId
+
     -- Range delete by (game_id, step) instead of materializing every step's
     -- UUID into an IN(...) list. Same row set, but the planner uses a single
     -- index scan on steps_game_step_idx and there's no client->server


### PR DESCRIPTION
## Summary
- Move the game step cursor before trimming future `arkham_steps` during multi-step undo.
- This keeps the `prevent_invalid_step_deletion` trigger satisfied when undoing action/turn/phase/round/scenario ranges.

## Problem
The multi-step undo path deleted `arkham_steps` with `step > toStep` while `arkham_games.step` still pointed at the current step. The database trigger rejects deleting steps that are less than or equal to the game's current step, so multi-step undo endpoints could fail with:

`Cannot delete step ... because it is equal to or less than the current step in the corresponding game.`

Single-step undo already updates the game step before deleting, so it was not affected.

## Verification
- `stack build --fast arkham-api:exe:arkham-api --ghc-options -DDEVELOPMENT --interleaved-output`
- Reproduced locally before the fix with `/undo/action` returning 500, then verified after the fix that `/undo/action` returned 200 and moved the game from step 60 to 58 while trimming `arkham_steps` to max step 58.
