### PR TITLE
Fix story back art codes

### DIFF
--- a/backend/arkham-api/arkham-api.cabal
+++ b/backend/arkham-api/arkham-api.cabal
@@ -7176,6 +7176,7 @@ test-suite spec
       Arkham.Skill.Cards.ViciousBlowSpec
       Arkham.Skill.Cards.WatchThisSpec
       Arkham.Story.Cards.UnfinishedBusinessSpec
+      Arkham.Story.CardsSpec
       Arkham.Treachery.Cards.AbandonedAndAloneSpec
       Arkham.Treachery.Cards.AmnesiaSpec
       Arkham.Treachery.Cards.BloodlustSpec

--- a/backend/arkham-api/library/Arkham/Story/Cards.hs
+++ b/backend/arkham-api/library/Arkham/Story/Cards.hs
@@ -262,7 +262,7 @@ sickeningReality_69 :: CardDef
 sickeningReality_69 = doubleSided $ story "03069" "Sickening Reality" TheLastKing
 
 engramsOath :: CardDef
-engramsOath = doubleSided $ story "03076b" "Engram's Oath" TheLastKing
+engramsOath = otherSideIs "03076a" $ story "03076b" "Engram's Oath" TheLastKing
 
 lagneauPerdu :: CardDef
 lagneauPerdu = doubleSided $ story "03077b" "L'agneau Perdu" TheLastKing
@@ -278,37 +278,37 @@ aboveAndBelow = doubleSided $ story "03080b" "Above and Below" TheLastKing
 
 songsThatTheHyadesShallSing :: CardDef
 songsThatTheHyadesShallSing =
-  doubleSided $ story "03325b" "Songs That the Hyades Shall Sing" DimCarcosa
+  otherSideIs "03325a" $ story "03325b" "Songs That the Hyades Shall Sing" DimCarcosa
 
 starsOfAldebaran :: CardDef
-starsOfAldebaran = doubleSided $ story "03326b" "Stars of Aldebaran" DimCarcosa
+starsOfAldebaran = otherSideIs "03326a" $ story "03326b" "Stars of Aldebaran" DimCarcosa
 
 bleakDesolation :: CardDef
-bleakDesolation = doubleSided $ story "03326d" "Bleak Desolation" DimCarcosa
+bleakDesolation = otherSideIs "03326c" $ story "03326d" "Bleak Desolation" DimCarcosa
 
 inhabitantOfCarcosa :: CardDef
-inhabitantOfCarcosa = doubleSided $ story "03327b" "Inhabitant of Carcosa" DimCarcosa
+inhabitantOfCarcosa = otherSideIs "03327a" $ story "03327b" "Inhabitant of Carcosa" DimCarcosa
 
 aMomentsRest :: CardDef
-aMomentsRest = doubleSided $ story "03327d" "A Moment's Rest" DimCarcosa
+aMomentsRest = otherSideIs "03327c" $ story "03327d" "A Moment's Rest" DimCarcosa
 
 theCoffin :: CardDef
-theCoffin = doubleSided $ story "03327f" "The Coffin" DimCarcosa
+theCoffin = otherSideIs "03327e" $ story "03327f" "The Coffin" DimCarcosa
 
 mappingTheStreets :: CardDef
-mappingTheStreets = doubleSided $ story "03328b" "Mapping the Streets" DimCarcosa
+mappingTheStreets = otherSideIs "03328a" $ story "03328b" "Mapping the Streets" DimCarcosa
 
 theKingsParade :: CardDef
-theKingsParade = doubleSided $ story "03328d" "The King's Parade" DimCarcosa
+theKingsParade = otherSideIs "03328c" $ story "03328d" "The King's Parade" DimCarcosa
 
 theArchway :: CardDef
-theArchway = doubleSided $ story "03328f" "The Archway" DimCarcosa
+theArchway = otherSideIs "03328e" $ story "03328f" "The Archway" DimCarcosa
 
 theHeightOfTheDepths :: CardDef
-theHeightOfTheDepths = doubleSided $ story "03329b" "The Height of the Depths" DimCarcosa
+theHeightOfTheDepths = otherSideIs "03329a" $ story "03329b" "The Height of the Depths" DimCarcosa
 
 stepsOfThePalace :: CardDef
-stepsOfThePalace = doubleSided $ story "03329d" "Steps of the Palace" DimCarcosa
+stepsOfThePalace = otherSideIs "03329c" $ story "03329d" "Steps of the Palace" DimCarcosa
 
 theFall :: CardDef
 theFall = doubleSided $ story "03330b" "The Fall" DimCarcosa
@@ -326,22 +326,28 @@ josefsPlan :: CardDef
 josefsPlan = doubleSided $ story "05085b" "Josef's Plan" AtDeathsDoorstep
 
 unfinishedBusiness_B :: CardDef
-unfinishedBusiness_B = victory 1 $ doubleSided $ story "05178b" "Unfinished Business" TheWagesOfSin
+unfinishedBusiness_B =
+  victory 1 $ otherSideIs "05178a" $ story "05178b" "Unfinished Business" TheWagesOfSin
 
 unfinishedBusiness_D :: CardDef
-unfinishedBusiness_D = victory 1 $ doubleSided $ story "05178d" "Unfinished Business" TheWagesOfSin
+unfinishedBusiness_D =
+  victory 1 $ otherSideIs "05178c" $ story "05178d" "Unfinished Business" TheWagesOfSin
 
 unfinishedBusiness_F :: CardDef
-unfinishedBusiness_F = victory 1 $ doubleSided $ story "05178f" "Unfinished Business" TheWagesOfSin
+unfinishedBusiness_F =
+  victory 1 $ otherSideIs "05178e" $ story "05178f" "Unfinished Business" TheWagesOfSin
 
 unfinishedBusiness_H :: CardDef
-unfinishedBusiness_H = victory 1 $ doubleSided $ story "05178h" "Unfinished Business" TheWagesOfSin
+unfinishedBusiness_H =
+  victory 1 $ otherSideIs "05178g" $ story "05178h" "Unfinished Business" TheWagesOfSin
 
 unfinishedBusiness_J :: CardDef
-unfinishedBusiness_J = victory 1 $ doubleSided $ story "05178j" "Unfinished Business" TheWagesOfSin
+unfinishedBusiness_J =
+  victory 1 $ otherSideIs "05178i" $ story "05178j" "Unfinished Business" TheWagesOfSin
 
 unfinishedBusiness_L :: CardDef
-unfinishedBusiness_L = victory 1 $ doubleSided $ story "05178l" "Unfinished Business" TheWagesOfSin
+unfinishedBusiness_L =
+  victory 1 $ otherSideIs "05178k" $ story "05178l" "Unfinished Business" TheWagesOfSin
 
 gavriellasFate :: CardDef
 gavriellasFate = doubleSided $ story "05262" "Gavriella's Fate" UnionAndDisillusion

--- a/backend/arkham-api/tests/Arkham/Story/Cards/UnfinishedBusinessSpec.hs
+++ b/backend/arkham-api/tests/Arkham/Story/Cards/UnfinishedBusinessSpec.hs
@@ -4,10 +4,30 @@ import Arkham.Enemy.Cards qualified as Enemies
 import Arkham.Matcher
 import Arkham.Placement
 import Arkham.Story.Cards qualified as Stories
+import TestImport qualified as TI
 import TestImport.New
 
 spec :: Spec
 spec = describe "Unfinished Business" $ do
+  it "links each story side back to its Heretic enemy side" do
+    map (.otherSide)
+      [ Stories.unfinishedBusiness_B
+      , Stories.unfinishedBusiness_D
+      , Stories.unfinishedBusiness_F
+      , Stories.unfinishedBusiness_H
+      , Stories.unfinishedBusiness_J
+      , Stories.unfinishedBusiness_L
+      ]
+      `TI.shouldBe` map
+        Just
+        [ "05178a"
+        , "05178c"
+        , "05178e"
+        , "05178g"
+        , "05178i"
+        , "05178k"
+        ]
+
   -- Errata (FAQ v1.6): "Keep this card in your threat area (this side faceup).
   -- If you are eliminated, flip it over." The card must flip back to its Heretic
   -- side rather than leaving play with the eliminated investigator.

--- a/backend/arkham-api/tests/Arkham/Story/CardsSpec.hs
+++ b/backend/arkham-api/tests/Arkham/Story/CardsSpec.hs
@@ -1,0 +1,38 @@
+module Arkham.Story.CardsSpec (spec) where
+
+import Arkham.Story.Cards qualified as Stories
+import TestImport qualified as TI
+import TestImport.New
+
+spec :: Spec
+spec = describe "Story card definitions" do
+  it "links printed story backs to their asset or location sides" do
+    map (.otherSide)
+      [ Stories.engramsOath
+      , Stories.songsThatTheHyadesShallSing
+      , Stories.starsOfAldebaran
+      , Stories.bleakDesolation
+      , Stories.inhabitantOfCarcosa
+      , Stories.aMomentsRest
+      , Stories.theCoffin
+      , Stories.mappingTheStreets
+      , Stories.theKingsParade
+      , Stories.theArchway
+      , Stories.theHeightOfTheDepths
+      , Stories.stepsOfThePalace
+      ]
+      `TI.shouldBe` map
+        Just
+        [ "03076a"
+        , "03325a"
+        , "03326a"
+        , "03326c"
+        , "03327a"
+        , "03327c"
+        , "03327e"
+        , "03328a"
+        , "03328c"
+        , "03328e"
+        , "03329a"
+        , "03329c"
+        ]


### PR DESCRIPTION
## Summary

Fix story cards that have printed extended-letter back art codes so they no longer derive nonexistent `...b` image names from their front-side card codes.

This covers the `05178` Unfinished Business series and the same pattern on several Path to Carcosa story cards.

## Root cause

These story cards were using `doubleSided`, which derives the back art by appending `b` to the front code. For cards like `05178f`, that produces `05178fb`, but the printed back art is `05178f`.

## Changes

- Use explicit `otherSideIs` back art codes for the affected story definitions.
- Add coverage for the Unfinished Business extended-letter cards.
- Add a broader story-card definition test for similar printed backs.

## Validation

- `stack test --test-arguments "--match \"art\""`
