### PR TITLE
[codex] Keep Unfinished Business story side faceup

### DIFF
--- a/backend/arkham-api/library/Arkham/Story/Cards/ReturnToUnfinishedBusiness_38.hs
+++ b/backend/arkham-api/library/Arkham/Story/Cards/ReturnToUnfinishedBusiness_38.hs
@@ -38,7 +38,6 @@ instance RunMessage ReturnToUnfinishedBusiness_38 where
         . ReturnToUnfinishedBusiness_38
         $ attrs
         & (placementL .~ InThreatArea iid)
-        & (flippedL .~ True)
         & (removeAfterResolutionL .~ False)
     UseThisAbility iid (isSource attrs -> True) 1 -> do
       chooseOneM iid $ withI18n do

--- a/backend/arkham-api/library/Arkham/Story/Cards/ReturnToUnfinishedBusiness_39.hs
+++ b/backend/arkham-api/library/Arkham/Story/Cards/ReturnToUnfinishedBusiness_39.hs
@@ -41,7 +41,6 @@ instance RunMessage ReturnToUnfinishedBusiness_39 where
         . ReturnToUnfinishedBusiness_39
         $ attrs
         & (placementL .~ InThreatArea iid)
-        & (flippedL .~ True)
         & (removeAfterResolutionL .~ False)
     UseThisAbility _iid (isSource attrs -> True) 1 -> do
       selectOne (enemyIs Enemies.theSpectralWatcher) >>= traverse_ readyThis

--- a/backend/arkham-api/library/Arkham/Story/Cards/UnfinishedBusiness_B.hs
+++ b/backend/arkham-api/library/Arkham/Story/Cards/UnfinishedBusiness_B.hs
@@ -41,7 +41,6 @@ instance RunMessage UnfinishedBusiness_B where
         . UnfinishedBusiness_B
         $ attrs
         & (placementL .~ InThreatArea iid)
-        & (flippedL .~ True)
         & (removeAfterResolutionL .~ False)
     UseCardAbility iid (isSource attrs -> True) 1 _ _ -> do
       chooseOneM iid $ withI18n do

--- a/backend/arkham-api/library/Arkham/Story/Cards/UnfinishedBusiness_D.hs
+++ b/backend/arkham-api/library/Arkham/Story/Cards/UnfinishedBusiness_D.hs
@@ -41,7 +41,6 @@ instance RunMessage UnfinishedBusiness_D where
         . UnfinishedBusiness_D
         $ attrs
         & (placementL .~ InThreatArea iid)
-        & (flippedL .~ True)
         & (removeAfterResolutionL .~ False)
     UseThisAbility iid (isSource attrs -> True) 1 -> do
       chooseOneM iid $ withI18n do

--- a/backend/arkham-api/library/Arkham/Story/Cards/UnfinishedBusiness_F.hs
+++ b/backend/arkham-api/library/Arkham/Story/Cards/UnfinishedBusiness_F.hs
@@ -43,7 +43,6 @@ instance RunMessage UnfinishedBusiness_F where
         . UnfinishedBusiness_F
         $ attrs
         & (placementL .~ InThreatArea iid)
-        & (flippedL .~ True)
         & (removeAfterResolutionL .~ False)
     UseThisAbility iid (isSource attrs -> True) 1 -> do
       hasEnoughResources <- fieldMap InvestigatorResources (>= 2) iid

--- a/backend/arkham-api/library/Arkham/Story/Cards/UnfinishedBusiness_H.hs
+++ b/backend/arkham-api/library/Arkham/Story/Cards/UnfinishedBusiness_H.hs
@@ -47,7 +47,6 @@ instance RunMessage UnfinishedBusiness_H where
         . UnfinishedBusiness_H
         $ attrs
         & (placementL .~ InThreatArea iid)
-        & (flippedL .~ True)
         & (removeAfterResolutionL .~ False)
     UseThisAbility iid (isSource attrs -> True) 1 -> do
       hasCards <-

--- a/backend/arkham-api/tests/Arkham/Story/Cards/UnfinishedBusinessSpec.hs
+++ b/backend/arkham-api/tests/Arkham/Story/Cards/UnfinishedBusinessSpec.hs
@@ -3,6 +3,8 @@ module Arkham.Story.Cards.UnfinishedBusinessSpec (spec) where
 import Arkham.Enemy.Cards qualified as Enemies
 import Arkham.Matcher
 import Arkham.Placement
+import Arkham.Projection (field)
+import Arkham.Story.Types (Field (StoryFlipped))
 import Arkham.Story.Cards qualified as Stories
 import TestImport qualified as TI
 import TestImport.New
@@ -40,3 +42,20 @@ spec = describe "Unfinished Business" $ do
     run $ Resign (toId investigator)
     chooseOnlyOption "flip Unfinished Business back over"
     assert $ selectAny (enemyIs Enemies.heretic_A)
+
+  it "keeps its story side faceup after resolving into an investigator's threat area" $ gameTest $ \investigator -> do
+    for_
+      [ (Stories.unfinishedBusiness_B, "05178b")
+      , (Stories.unfinishedBusiness_D, "05178d")
+      , (Stories.unfinishedBusiness_F, "05178f")
+      , (Stories.unfinishedBusiness_H, "05178h")
+      , (Stories.returnToUnfinishedBusiness_38, "54038b")
+      , (Stories.returnToUnfinishedBusiness_39, "54039b")
+      ]
+      \(storyCard, storyId) -> do
+        card <- genCard storyCard
+        run $ StoryMessage $ ReadStoryWithPlacement (toId investigator) card ResolveIt Nothing (InThreatArea $ toId investigator)
+
+        field StoryFlipped storyId `shouldReturn` False
+        chooseOnlyOption "resolve Unfinished Business"
+        field StoryFlipped storyId `shouldReturn` False


### PR DESCRIPTION
## Summary
- Keep Unfinished Business story-side cards faceup after ResolveStory places them in a threat area.
- Cover the original B/D/F/H and Return To 38/39 variants with a regression test.

## Root cause
`ReadStoryWithPlacement` creates these entities using the story-side art (`05178b/d/f/h`, `54038b/54039b`). Their `ResolveThisStory` handlers then set `storyFlipped` to `True`, causing the frontend to render `flippedArt`, i.e. the Heretic side.

## Testing
- `git diff --check`
- `stack test arkham-api:test:spec --test-arguments='--match "Unfinished Business"'`