### PR TITLE
[codex] Default omitted token maps

### DIFF
--- a/frontend/src/arkham/types/Token.ts
+++ b/frontend/src/arkham/types/Token.ts
@@ -1,4 +1,5 @@
 import * as JsonDecoder from 'ts.data.json';
+import { withDefault } from '@/arkham/parser';
 
 export const TOKENS = [
   "Aether",
@@ -84,8 +85,10 @@ export type Tokens = Partial<Record<Token, number>>;
 export function isUse(t: Token): boolean {
   return t !== 'Damage' && t !== 'Horror' && t !== 'Clue' && t !== 'Doom';
 }
-export const tokensDecoder =
+const tokenPairsDecoder =
   JsonDecoder.array<[Token, number]>(
     JsonDecoder.tuple([tokenDecoder, JsonDecoder.number()], 'Token[]'),
     'Token[]'
   ).map<{ [key in Token]?: number}>(pairs => pairs.reduce((acc, v) => ({ ...acc, [v[0]]: v[1] }), {}))
+
+export const tokensDecoder = withDefault({}, tokenPairsDecoder)


### PR DESCRIPTION
## Summary

Treat omitted or null token maps as empty token maps in the frontend decoder.

## Why

Some slimmed game payloads omit empty `tokens` fields. The previous `tokensDecoder` only accepted an explicit token-pair array, so a payload with an omitted empty token map could fail `gameDecoder` and leave the game view blank.

## Change

- Split the existing token-pair array decoder into `tokenPairsDecoder`.
- Wrap `tokensDecoder` with the existing `withDefault({}, ...)` helper so omitted or null token maps decode as `{}`.

## Validation

- `npm run tc`
- `node --test tests/upgradeDeckUpload.test.mjs`
- `npm run build`
- Reproduced payload validation through Vite SSR: `gameDecoder: OK`

Note: `npm test` currently fails before running tests because `node --test tests/**/*.test.mjs` is not expanded in this shell; the existing test file passes when invoked by explicit path.
