### PR TITLE
Add Simplified Chinese card data

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,9 +13,10 @@
     "lint:fix": "eslint src --fix",
     "format": "prettier --write \"src/**/*.{ts,vue}\"",
     "format:check": "prettier --check \"src/**/*.{ts,vue}\"",
-    "test": "node --test tests/**/*.test.mjs",
+    "test": "node --test tests/**/*.test.mjs scripts/*.test.cjs",
     "digest": "node ./scripts/digest.cjs",
     "fetch-card-data": "node ./scripts/fetch-card-data.cjs --slim",
+    "import-zh-cn-cards": "node ./scripts/import-card-translations.cjs --source-locale zh-cn --output-lang zh --slim",
     "slim-cards": "node ./scripts/slim-cards.cjs"
   },
   "dependencies": {

--- a/frontend/scripts/import-card-translations.cjs
+++ b/frontend/scripts/import-card-translations.cjs
@@ -1,0 +1,195 @@
+#!/usr/bin/env node
+
+const fs = require('fs')
+const path = require('path')
+const { spawnSync } = require('child_process')
+const { isDeepStrictEqual } = require('util')
+
+const TRANSLATED_FIELDS = [
+  'name',
+  'subname',
+  'text',
+  'traits',
+  'flavor',
+  'slot',
+  'back_name',
+  'back_subname',
+  'back_text',
+  'back_traits',
+  'back_flavor',
+  'customization_text',
+  'customization_change',
+]
+
+const METADATA_FIELDS = [
+  ['pack_code', 'pack_name', 'packs'],
+  ['type_code', 'type_name', 'types'],
+  ['subtype_code', 'subtype_name', 'subtypes'],
+  ['faction_code', 'faction_name', 'factions'],
+  ['faction2_code', 'faction2_name', 'factions'],
+  ['faction3_code', 'faction3_name', 'factions'],
+  ['encounter_code', 'encounter_name', 'encounters'],
+  ['cycle_code', 'cycle_name', 'cycles'],
+]
+
+function buildLocalizedCards(englishCards, translations, metadata = {}) {
+  const used = new Set()
+  let translated = 0
+  let reused = 0
+
+  const identityFor = (card) =>
+    JSON.stringify([
+      card.real_name ?? card.name ?? null,
+      card.subname || '',
+      card.real_text || card.text || '',
+      card.real_traits || card.traits || '',
+      card.back_name || '',
+      card.back_text || '',
+      card.type_code ?? null,
+      card.faction_code ?? null,
+      card.xp ?? null,
+      card.customization_text || '',
+    ])
+
+  const reusableTranslations = new Map()
+  for (const card of englishCards) {
+    const translation = translations.get(card.code)
+    if (translation) reusableTranslations.set(identityFor(card), translation)
+  }
+
+  const cards = englishCards.map((card) => {
+    const localized = { ...card }
+    const directTranslation = translations.get(card.code)
+    const sideTranslation =
+      !directTranslation && card.code.endsWith('b')
+        ? translations.get(card.code.slice(0, -1))
+        : undefined
+    const translation =
+      directTranslation ?? sideTranslation ?? reusableTranslations.get(identityFor(card))
+
+    if (translation) {
+      used.add(translation.code)
+      if (directTranslation) {
+        translated += 1
+      } else {
+        reused += 1
+      }
+      for (const field of TRANSLATED_FIELDS) {
+        if (translation[field] !== undefined) localized[field] = translation[field]
+      }
+    }
+
+    for (const [codeField, nameField, metadataKey] of METADATA_FIELDS) {
+      const code = localized[codeField]
+      const name = metadata[metadataKey]?.get(code)
+      if (name !== undefined) localized[nameField] = name
+    }
+
+    return localized
+  })
+
+  return {
+    cards,
+    stats: {
+      total: englishCards.length,
+      translated,
+      reused,
+      fallback: englishCards.length - translated - reused,
+      unused: translations.size - used.size,
+    },
+  }
+}
+
+function jsonFilesUnder(root) {
+  const files = []
+  for (const entry of fs.readdirSync(root, { withFileTypes: true })) {
+    const target = path.join(root, entry.name)
+    if (entry.isDirectory()) files.push(...jsonFilesUnder(target))
+    else if (entry.isFile() && entry.name.endsWith('.json')) files.push(target)
+  }
+  return files.sort()
+}
+
+function loadTranslations(localeRoot) {
+  const translations = new Map()
+  for (const file of jsonFilesUnder(path.join(localeRoot, 'pack'))) {
+    const cards = JSON.parse(fs.readFileSync(file, 'utf8'))
+    if (!Array.isArray(cards)) throw new Error(`${file} must contain a JSON array`)
+
+    for (const card of cards) {
+      if (!card.code) throw new Error(`${file} contains a card without a code`)
+      const existing = translations.get(card.code)
+      if (existing && !isDeepStrictEqual(existing, card)) {
+        throw new Error(`Conflicting translations for card ${card.code}`)
+      }
+      translations.set(card.code, card)
+    }
+  }
+  return translations
+}
+
+function loadMetadata(localeRoot) {
+  const metadata = {}
+  for (const key of ['packs', 'types', 'subtypes', 'factions', 'encounters', 'cycles']) {
+    const file = path.join(localeRoot, `${key}.json`)
+    if (!fs.existsSync(file)) continue
+    const entries = JSON.parse(fs.readFileSync(file, 'utf8'))
+    metadata[key] = new Map(entries.map(({ code, name }) => [code, name]))
+  }
+  return metadata
+}
+
+function parseArgs(args) {
+  const options = { sourceLocale: 'zh-cn', outputLang: 'zh', slim: false }
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i]
+    if (arg === '--source') options.source = args[++i]
+    else if (arg === '--source-locale') options.sourceLocale = args[++i]
+    else if (arg === '--output-lang') options.outputLang = args[++i]
+    else if (arg === '--slim') options.slim = true
+    else if (arg === '--help' || arg === '-h') options.help = true
+    else throw new Error(`Unknown argument: ${arg}`)
+  }
+  return options
+}
+
+function main() {
+  const root = path.join(__dirname, '..')
+  const options = parseArgs(process.argv.slice(2))
+  if (options.help) {
+    console.log('Usage: node scripts/import-card-translations.cjs [--source PATH] [--source-locale zh-cn] [--output-lang zh] [--slim]')
+    return
+  }
+
+  const source = path.resolve(
+    options.source || process.env.ARKHAMDB_JSON_DATA_DIR || path.join(root, '..', '..', 'arkhamdb-json-data'),
+  )
+  const localeRoot = path.join(source, 'translations', options.sourceLocale)
+  if (!fs.existsSync(localeRoot)) throw new Error(`Translation locale not found: ${localeRoot}`)
+
+  const englishFile = path.join(root, 'public', 'cards_en.json')
+  const outputFile = path.join(root, 'public', `cards_${options.outputLang}.json`)
+  const englishCards = JSON.parse(fs.readFileSync(englishFile, 'utf8'))
+  const translations = loadTranslations(localeRoot)
+  const metadata = loadMetadata(localeRoot)
+  const { cards, stats } = buildLocalizedCards(englishCards, translations, metadata)
+
+  fs.writeFileSync(outputFile, `${JSON.stringify(cards, null, 2)}\n`)
+  console.log(
+    `${options.sourceLocale} -> ${options.outputLang}: ${stats.translated}/${stats.total} translated, ` +
+      `${stats.reused} reprints reused, ${stats.fallback} English fallbacks, ` +
+      `${stats.unused} unused -> ${outputFile}`,
+  )
+
+  if (options.slim) {
+    const result = spawnSync(process.execPath, ['scripts/slim-cards.cjs'], {
+      cwd: root,
+      stdio: 'inherit',
+    })
+    if (result.status !== 0) process.exit(result.status ?? 1)
+  }
+}
+
+if (require.main === module) main()
+
+module.exports = { buildLocalizedCards, loadMetadata, loadTranslations, parseArgs }

--- a/frontend/scripts/import-card-translations.test.cjs
+++ b/frontend/scripts/import-card-translations.test.cjs
@@ -1,0 +1,103 @@
+const assert = require('node:assert/strict')
+const test = require('node:test')
+
+const { buildLocalizedCards } = require('./import-card-translations.cjs')
+
+test('merges translated card text and localized metadata onto the English export', () => {
+  const cards = [
+    {
+      code: '01001',
+      name: 'Roland Banks',
+      text: 'English text',
+      real_name: 'Roland Banks',
+      pack_code: 'core',
+      pack_name: 'Core Set',
+      type_code: 'investigator',
+      type_name: 'Investigator',
+      faction_code: 'guardian',
+      faction_name: 'Guardian',
+      encounter_code: 'rats',
+      encounter_name: 'Rats',
+    },
+    { code: '01002', name: 'Daisy Walker', real_name: 'Daisy Walker' },
+  ]
+  const translations = new Map([
+    [
+      '01001',
+      {
+        code: '01001',
+        name: '罗兰·班克斯',
+        text: '简体中文文本',
+        deck_limit: 99,
+      },
+    ],
+  ])
+  const metadata = {
+    packs: new Map([['core', '核心游戏']]),
+    types: new Map([['investigator', '调查员']]),
+    factions: new Map([['guardian', '守护者']]),
+    encounters: new Map([['rats', '鼠群']]),
+  }
+
+  const result = buildLocalizedCards(cards, translations, metadata)
+
+  assert.equal(result.cards[0].name, '罗兰·班克斯')
+  assert.equal(result.cards[0].text, '简体中文文本')
+  assert.equal(result.cards[0].real_name, 'Roland Banks')
+  assert.equal(result.cards[0].pack_name, '核心游戏')
+  assert.equal(result.cards[0].type_name, '调查员')
+  assert.equal(result.cards[0].faction_name, '守护者')
+  assert.equal(result.cards[0].encounter_name, '鼠群')
+  assert.notEqual(result.cards[0].deck_limit, 99)
+  assert.equal(result.cards[1].name, 'Daisy Walker')
+  assert.deepEqual(result.stats, { total: 2, translated: 1, reused: 0, fallback: 1, unused: 0 })
+})
+
+test('reuses a translation for an equivalent reprint with a different card code', () => {
+  const shared = {
+    name: 'Beat Cop',
+    real_name: 'Beat Cop',
+    text: '',
+    real_text: '',
+    traits: 'Ally. Police.',
+    real_traits: 'Ally. Police.',
+    type_code: 'asset',
+    xp: 0,
+  }
+  const result = buildLocalizedCards(
+    [
+      { ...shared, code: '01018' },
+      { ...shared, code: '01518', pack_code: 'rcore', text: null, real_text: null },
+    ],
+    new Map([['01018', { code: '01018', name: '巡警', text: '简体中文文本', traits: '盟友. 警察.' }]]),
+    {},
+  )
+
+  assert.equal(result.cards[1].name, '巡警')
+  assert.equal(result.cards[1].text, '简体中文文本')
+  assert.deepEqual(result.stats, { total: 2, translated: 1, reused: 1, fallback: 0, unused: 0 })
+})
+
+test('reuses an unsuffixed translation for a split card-side code', () => {
+  const result = buildLocalizedCards(
+    [{ code: '86024b', name: 'Hub Dimension', text: 'English text' }],
+    new Map([['86024', { code: '86024', name: '次元枢纽', text: '简体中文文本' }]]),
+    {},
+  )
+
+  assert.equal(result.cards[0].name, '次元枢纽')
+  assert.deepEqual(result.stats, { total: 1, translated: 0, reused: 1, fallback: 0, unused: 0 })
+})
+
+test('reports translations that do not match a card in the English export', () => {
+  const result = buildLocalizedCards(
+    [{ code: '01001', name: 'Roland Banks' }],
+    new Map([
+      ['01001', { code: '01001', name: '罗兰·班克斯' }],
+      ['missing', { code: 'missing', name: '不存在' }],
+    ]),
+    {},
+  )
+
+  assert.equal(result.stats.unused, 1)
+})


### PR DESCRIPTION
## Summary

- replace the existing Traditional Chinese `cards_zh.json` export with reviewed Simplified Chinese card data from `llwwbb/arkhamdb-json-data@5a50915b`
- add a reproducible importer that overlays translated text and metadata onto the current English export without changing gameplay fields
- reuse translations for equivalent reprints and split card-side codes so all 5,929 current cards have localized text
- add focused Node tests for field merging, reprints, split sides, and unused translations

## Why

The existing `zh` application locale is Simplified Chinese, while its bundled card metadata is primarily Traditional Chinese and is incomplete for newer cards. Keeping the generated card data in the main branch makes the update available to every deployment that selects `zh`, rather than limiting it to a downstream deployment branch.

The generated result contains 5,789 direct translations and 140 equivalent reprints, with no English fallbacks and no unused source translations.

## Validation

- `npm test` (7 tests)
- `npm run tc`
- `node --test scripts/zh-cn/test/*.test.js` in the translation source repository (231 tests)
- regenerated `cards_zh.json` from the source repository with zero diff
