### PR TITLE
Add a separate Simplified Chinese locale

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,6 +16,7 @@
     "test": "node --test tests/**/*.test.mjs",
     "digest": "node ./scripts/digest.cjs",
     "fetch-card-data": "node ./scripts/fetch-card-data.cjs --slim",
+    "import-zh-cn-cards": "node ./scripts/import-card-translations.cjs --source-locale zh-cn --output-lang zh-cn --slim",
     "slim-cards": "node ./scripts/slim-cards.cjs"
   },
   "dependencies": {

--- a/frontend/scripts/card-data-files.cjs
+++ b/frontend/scripts/card-data-files.cjs
@@ -1,0 +1,7 @@
+const CARD_DATA_FILENAME = /^cards_[a-z]+(?:-[a-z]+)?\.json$/
+
+function isCardDataFilename(filename) {
+  return CARD_DATA_FILENAME.test(filename)
+}
+
+module.exports = { isCardDataFilename }

--- a/frontend/scripts/import-card-translations.cjs
+++ b/frontend/scripts/import-card-translations.cjs
@@ -1,0 +1,197 @@
+#!/usr/bin/env node
+
+const fs = require('fs')
+const path = require('path')
+const { spawnSync } = require('child_process')
+const { isDeepStrictEqual } = require('util')
+
+const TRANSLATED_FIELDS = [
+  'name',
+  'subname',
+  'text',
+  'traits',
+  'flavor',
+  'slot',
+  'back_name',
+  'back_subname',
+  'back_text',
+  'back_traits',
+  'back_flavor',
+  'customization_text',
+  'customization_change',
+]
+
+const METADATA_FIELDS = [
+  ['pack_code', 'pack_name', 'packs'],
+  ['type_code', 'type_name', 'types'],
+  ['subtype_code', 'subtype_name', 'subtypes'],
+  ['faction_code', 'faction_name', 'factions'],
+  ['faction2_code', 'faction2_name', 'factions'],
+  ['faction3_code', 'faction3_name', 'factions'],
+  ['encounter_code', 'encounter_name', 'encounters'],
+  ['cycle_code', 'cycle_name', 'cycles'],
+]
+
+function buildLocalizedCards(englishCards, translations, metadata = {}) {
+  const used = new Set()
+  let translated = 0
+  let reused = 0
+
+  const identityFor = (card) =>
+    JSON.stringify([
+      card.real_name ?? card.name ?? null,
+      card.subname || '',
+      card.real_text || card.text || '',
+      card.real_traits || card.traits || '',
+      card.back_name || '',
+      card.back_text || '',
+      card.type_code ?? null,
+      card.faction_code ?? null,
+      card.xp ?? null,
+      card.customization_text || '',
+    ])
+
+  const reusableTranslations = new Map()
+  for (const card of englishCards) {
+    const translation = translations.get(card.code)
+    if (translation) reusableTranslations.set(identityFor(card), translation)
+  }
+
+  const cards = englishCards.map((card) => {
+    const localized = { ...card }
+    const directTranslation = translations.get(card.code)
+    const sideTranslation =
+      !directTranslation && card.code.endsWith('b')
+        ? translations.get(card.code.slice(0, -1))
+        : undefined
+    const translation =
+      directTranslation ?? sideTranslation ?? reusableTranslations.get(identityFor(card))
+
+    if (translation) {
+      used.add(translation.code)
+      if (directTranslation) translated += 1
+      else reused += 1
+
+      for (const field of TRANSLATED_FIELDS) {
+        if (translation[field] !== undefined) localized[field] = translation[field]
+      }
+    }
+
+    for (const [codeField, nameField, metadataKey] of METADATA_FIELDS) {
+      const code = localized[codeField]
+      const name = metadata[metadataKey]?.get(code)
+      if (name !== undefined) localized[nameField] = name
+    }
+
+    return localized
+  })
+
+  return {
+    cards,
+    stats: {
+      total: englishCards.length,
+      translated,
+      reused,
+      fallback: englishCards.length - translated - reused,
+      unused: translations.size - used.size,
+    },
+  }
+}
+
+function jsonFilesUnder(root) {
+  const files = []
+  for (const entry of fs.readdirSync(root, { withFileTypes: true })) {
+    const target = path.join(root, entry.name)
+    if (entry.isDirectory()) files.push(...jsonFilesUnder(target))
+    else if (entry.isFile() && entry.name.endsWith('.json')) files.push(target)
+  }
+  return files.sort()
+}
+
+function loadTranslations(localeRoot) {
+  const translations = new Map()
+  for (const file of jsonFilesUnder(path.join(localeRoot, 'pack'))) {
+    const cards = JSON.parse(fs.readFileSync(file, 'utf8'))
+    if (!Array.isArray(cards)) throw new Error(`${file} must contain a JSON array`)
+
+    for (const card of cards) {
+      if (!card.code) throw new Error(`${file} contains a card without a code`)
+      const existing = translations.get(card.code)
+      if (existing && !isDeepStrictEqual(existing, card)) {
+        throw new Error(`Conflicting translations for card ${card.code}`)
+      }
+      translations.set(card.code, card)
+    }
+  }
+  return translations
+}
+
+function loadMetadata(localeRoot) {
+  const metadata = {}
+  for (const key of ['packs', 'types', 'subtypes', 'factions', 'encounters', 'cycles']) {
+    const file = path.join(localeRoot, `${key}.json`)
+    if (!fs.existsSync(file)) continue
+    const entries = JSON.parse(fs.readFileSync(file, 'utf8'))
+    metadata[key] = new Map(entries.map(({ code, name }) => [code, name]))
+  }
+  return metadata
+}
+
+function parseArgs(args) {
+  const options = { sourceLocale: 'zh-cn', outputLang: 'zh-cn', slim: false }
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i]
+    if (arg === '--source') options.source = args[++i]
+    else if (arg === '--source-locale') options.sourceLocale = args[++i]
+    else if (arg === '--output-lang') options.outputLang = args[++i]
+    else if (arg === '--slim') options.slim = true
+    else if (arg === '--help' || arg === '-h') options.help = true
+    else throw new Error(`Unknown argument: ${arg}`)
+  }
+  return options
+}
+
+function main() {
+  const root = path.join(__dirname, '..')
+  const options = parseArgs(process.argv.slice(2))
+  if (options.help) {
+    console.log(
+      'Usage: node scripts/import-card-translations.cjs [--source PATH] [--source-locale zh-cn] [--output-lang zh-cn] [--slim]',
+    )
+    return
+  }
+
+  const source = path.resolve(
+    options.source ||
+      process.env.ARKHAMDB_JSON_DATA_DIR ||
+      path.join(root, '..', '..', 'arkhamdb-json-data'),
+  )
+  const localeRoot = path.join(source, 'translations', options.sourceLocale)
+  if (!fs.existsSync(localeRoot)) throw new Error(`Translation locale not found: ${localeRoot}`)
+
+  const englishFile = path.join(root, 'public', 'cards_en.json')
+  const outputFile = path.join(root, 'public', `cards_${options.outputLang}.json`)
+  const englishCards = JSON.parse(fs.readFileSync(englishFile, 'utf8'))
+  const translations = loadTranslations(localeRoot)
+  const metadata = loadMetadata(localeRoot)
+  const { cards, stats } = buildLocalizedCards(englishCards, translations, metadata)
+
+  fs.writeFileSync(outputFile, `${JSON.stringify(cards, null, 2)}\n`)
+  console.log(
+    `${options.sourceLocale} -> ${options.outputLang}: ${stats.translated}/${stats.total} translated, ` +
+      `${stats.reused} reprints reused, ${stats.fallback} English fallbacks, ` +
+      `${stats.unused} unused -> ${outputFile}`,
+  )
+
+  if (options.slim) {
+    const result = spawnSync(process.execPath, ['scripts/slim-cards.cjs'], {
+      cwd: root,
+      stdio: 'inherit',
+    })
+    if (result.status !== 0) process.exit(result.status ?? 1)
+  }
+}
+
+if (require.main === module) main()
+
+module.exports = { buildLocalizedCards, loadMetadata, loadTranslations, parseArgs }

--- a/frontend/scripts/import-card-translations.cjs
+++ b/frontend/scripts/import-card-translations.cjs
@@ -139,11 +139,17 @@ function loadMetadata(localeRoot) {
 
 function parseArgs(args) {
   const options = { sourceLocale: 'zh-cn', outputLang: 'zh-cn', slim: false }
+  const readValue = (option, index) => {
+    const value = args[index]
+    if (!value || value.startsWith('-')) throw new Error(`${option} requires a value`)
+    return value
+  }
+
   for (let i = 0; i < args.length; i += 1) {
     const arg = args[i]
-    if (arg === '--source') options.source = args[++i]
-    else if (arg === '--source-locale') options.sourceLocale = args[++i]
-    else if (arg === '--output-lang') options.outputLang = args[++i]
+    if (arg === '--source') options.source = readValue(arg, ++i)
+    else if (arg === '--source-locale') options.sourceLocale = readValue(arg, ++i)
+    else if (arg === '--output-lang') options.outputLang = readValue(arg, ++i)
     else if (arg === '--slim') options.slim = true
     else if (arg === '--help' || arg === '-h') options.help = true
     else throw new Error(`Unknown argument: ${arg}`)

--- a/frontend/scripts/slim-cards.cjs
+++ b/frontend/scripts/slim-cards.cjs
@@ -10,6 +10,7 @@
 const fs = require('fs')
 const path = require('path')
 const zlib = require('zlib')
+const { isCardDataFilename } = require('./card-data-files.cjs')
 
 const KEEP_FIELDS = [
   'code',
@@ -48,7 +49,7 @@ if (!fs.existsSync(outDir)) fs.mkdirSync(outDir, { recursive: true })
 
 const sources = fs
   .readdirSync(publicDir)
-  .filter((f) => /^cards_[a-z]+\.json$/.test(f))
+  .filter(isCardDataFilename)
 
 if (sources.length === 0) {
   console.error('No cards_*.json source files found in', publicDir)

--- a/frontend/src/arkham/helpers.ts
+++ b/frontend/src/arkham/helpers.ts
@@ -132,7 +132,8 @@ export function pluralize(w: string, n: number) {
     case 'ko': {
       return `${w} ${n}`
     }
-    case 'zh': {
+    case 'zh':
+    case 'zh-cn': {
       return `${n}${w}${n == 1 ? '' : ''}`
     }
     default: return `${n} ${w}${n == 1 ? '' : 's'}`

--- a/frontend/src/components/SettingsForm.vue
+++ b/frontend/src/components/SettingsForm.vue
@@ -75,6 +75,7 @@ const updateLanguage = async (a: Event) => {
           <option value="po">Português/Portuguese</option>
           <option value="ru">Русский/Russian</option>
           <option value="uk">українська/Ukrainian</option>
+          <option value="zh-cn">简体中文/Simplified Chinese</option>
           <option value="zh">中文/Chinese</option>
         </select>
       </section>

--- a/frontend/src/components/SettingsForm.vue
+++ b/frontend/src/components/SettingsForm.vue
@@ -49,7 +49,7 @@ const updateLanguage = async (a: Event) => {
   }
 
   language.value = selectedLanguage
-  locale.value = selectedLanguage
+  locale.value = uiLocale
   localStorage.setItem('language', selectedLanguage)
   await store.initDbCards()
   await checkImageExists()

--- a/frontend/src/locales/language.ts
+++ b/frontend/src/locales/language.ts
@@ -1,0 +1,25 @@
+export const uiLocales = ['en', 'fr', 'it', 'ko', 'es', 'zh'] as const
+
+export type UiLocale = (typeof uiLocales)[number]
+
+export function uiLocaleFor(language: string): UiLocale {
+  const normalized = language.toLowerCase()
+  const candidate = normalized === 'zh-cn' ? 'zh' : normalized
+  return uiLocales.includes(candidate as UiLocale) ? (candidate as UiLocale) : 'en'
+}
+
+export function preferredLanguage(browserLocale: string): string {
+  const normalized = browserLocale.trim().toLowerCase()
+  if (!normalized) return 'en'
+
+  const [language, ...subtags] = normalized.split('-')
+  if (language !== 'zh') return language
+
+  if (subtags.includes('hant')) return 'zh'
+
+  if (subtags.includes('hans') || subtags.includes('cn') || subtags.includes('sg')) {
+    return 'zh-cn'
+  }
+
+  return 'zh'
+}

--- a/frontend/src/locales/messages.ts
+++ b/frontend/src/locales/messages.ts
@@ -1,3 +1,5 @@
+import { uiLocaleFor, type UiLocale } from '@/locales/language'
+
 const localeLoaders = {
   en: () => import('@/locales/en'),
   fr: () => import('@/locales/fr'),
@@ -5,14 +7,14 @@ const localeLoaders = {
   ko: () => import('@/locales/ko'),
   es: () => import('@/locales/es'),
   zh: () => import('@/locales/zh'),
-}
+} satisfies Record<UiLocale, () => Promise<unknown>>
 
 export type SupportedLocale = keyof typeof localeLoaders
 
 export const supportedLocales = Object.keys(localeLoaders) as SupportedLocale[]
 
 export function normalizeLocale(locale: string): SupportedLocale {
-  return supportedLocales.includes(locale as SupportedLocale) ? locale as SupportedLocale : 'en'
+  return uiLocaleFor(locale)
 }
 
 export async function loadLocaleMessages(locale: string) {

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -12,13 +12,14 @@ import { faExpeditedssl } from "@fortawesome/free-brands-svg-icons";
 import { faBan, faCircleExclamation, faGhost, faLocationDot, faSearch, faList, faImage, faAngleDown, faUndo, faTrash, faEye, faCopy, faExternalLink, faRefresh, faBook, faChevronRight, faBars, faTimes, faShieldHeart, faWrench, faPaperclip, faArrowLeft, faArrowUp, faStore, faTriangleExclamation, faShuffle, faTrophy } from '@fortawesome/free-solid-svg-icons'
 import * as VueI18n from 'vue-i18n'
 import { loadLocaleMessages, normalizeLocale } from '@/locales/messages'
+import { preferredLanguage } from '@/locales/language'
 import mitt from 'mitt';
 
 library.add(faBan, faLocationDot, faCircleExclamation, faGhost, faSearch, faList, faImage, faAngleDown, faExpeditedssl, faUndo, faTrash, faEye, faCopy, faExternalLink, faRefresh, faBook, faChevronRight, faBars, faTimes, faShieldHeart, faWrench, faPaperclip, faArrowLeft, faArrowUp, faStore, faTriangleExclamation, faShuffle, faTrophy)
 
 async function bootstrap() {
   const language = localStorage.getItem('language')
-  const naviLanguage = (navigator.language || 'en').split('-')[0]
+  const naviLanguage = preferredLanguage(navigator.language || 'en')
   const currentLanguage = language ?? naviLanguage
   const currentLocale = normalizeLocale(currentLanguage)
   if (!language) { localStorage.setItem('language', currentLanguage) }

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -34,7 +34,7 @@ async function bootstrap() {
   }
 
   const i18n = VueI18n.createI18n({
-    locale: currentLanguage, // set locale
+    locale: currentLocale, // set locale
     fallbackLocale: 'en', // set fallback locale
     legacy: false,
     warnHtmlMessage: false,

--- a/frontend/tests/cardDataFiles.test.mjs
+++ b/frontend/tests/cardDataFiles.test.mjs
@@ -1,0 +1,16 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import cardDataFiles from '../scripts/card-data-files.cjs'
+
+const { isCardDataFilename } = cardDataFiles
+
+test('card data filenames support a language-region suffix', () => {
+  assert.equal(isCardDataFilename('cards_zh-cn.json'), true)
+  assert.equal(isCardDataFilename('cards_zh.json'), true)
+})
+
+test('card data filenames reject unrelated and unsafe paths', () => {
+  assert.equal(isCardDataFilename('cards_zh-cn.json.tmp'), false)
+  assert.equal(isCardDataFilename('../cards_zh-cn.json'), false)
+})

--- a/frontend/tests/importCardTranslations.test.mjs
+++ b/frontend/tests/importCardTranslations.test.mjs
@@ -1,0 +1,67 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import importer from '../scripts/import-card-translations.cjs'
+
+const { buildLocalizedCards, parseArgs } = importer
+
+test('the Simplified Chinese importer writes a separate zh-cn locale by default', () => {
+  assert.deepEqual(parseArgs([]), { sourceLocale: 'zh-cn', outputLang: 'zh-cn', slim: false })
+})
+
+test('translated text is merged without replacing gameplay metadata', () => {
+  const cards = [
+    {
+      code: '01001',
+      name: 'Roland Banks',
+      text: 'English text',
+      real_name: 'Roland Banks',
+      pack_code: 'core',
+      pack_name: 'Core Set',
+    },
+  ]
+  const translations = new Map([
+    ['01001', { code: '01001', name: '罗兰·班克斯', text: '简体中文文本', deck_limit: 99 }],
+  ])
+  const metadata = { packs: new Map([['core', '基础游戏']]) }
+
+  const result = buildLocalizedCards(cards, translations, metadata)
+
+  assert.equal(result.cards[0].name, '罗兰·班克斯')
+  assert.equal(result.cards[0].text, '简体中文文本')
+  assert.equal(result.cards[0].real_name, 'Roland Banks')
+  assert.equal(result.cards[0].pack_name, '基础游戏')
+  assert.notEqual(result.cards[0].deck_limit, 99)
+})
+
+test('equivalent reprints reuse an existing Simplified Chinese translation', () => {
+  const shared = {
+    name: 'Beat Cop',
+    real_name: 'Beat Cop',
+    text: '',
+    real_text: '',
+    traits: 'Ally. Police.',
+    real_traits: 'Ally. Police.',
+    type_code: 'asset',
+    xp: 0,
+  }
+  const result = buildLocalizedCards(
+    [
+      { ...shared, code: '01018' },
+      { ...shared, code: '01518', text: null, real_text: null },
+    ],
+    new Map([['01018', { code: '01018', name: '巡警', text: '简体中文文本' }]]),
+  )
+
+  assert.equal(result.cards[1].name, '巡警')
+  assert.deepEqual(result.stats, { total: 2, translated: 1, reused: 1, fallback: 0, unused: 0 })
+})
+
+test('split card sides reuse an unsuffixed translation', () => {
+  const result = buildLocalizedCards(
+    [{ code: '86024b', name: 'Hub Dimension', text: 'English text' }],
+    new Map([['86024', { code: '86024', name: '次元枢纽', text: '简体中文文本' }]]),
+  )
+
+  assert.equal(result.cards[0].name, '次元枢纽')
+})

--- a/frontend/tests/importCardTranslations.test.mjs
+++ b/frontend/tests/importCardTranslations.test.mjs
@@ -9,6 +9,13 @@ test('the Simplified Chinese importer writes a separate zh-cn locale by default'
   assert.deepEqual(parseArgs([]), { sourceLocale: 'zh-cn', outputLang: 'zh-cn', slim: false })
 })
 
+test('translation importer options require a value', () => {
+  for (const option of ['--source', '--source-locale', '--output-lang']) {
+    assert.throws(() => parseArgs([option]), new RegExp(`${option} requires a value`))
+    assert.throws(() => parseArgs([option, '--slim']), new RegExp(`${option} requires a value`))
+  }
+})
+
 test('translated text is merged without replacing gameplay metadata', () => {
   const cards = [
     {

--- a/frontend/tests/language.test.mjs
+++ b/frontend/tests/language.test.mjs
@@ -1,0 +1,52 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import { resolve } from 'node:path'
+import test from 'node:test'
+import ts from 'typescript'
+
+async function importTsModule(path) {
+  const source = await readFile(path, 'utf8')
+  const { outputText } = ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.ES2022,
+      target: ts.ScriptTarget.ES2022,
+      verbatimModuleSyntax: true,
+    },
+    fileName: path,
+  })
+
+  return import(`data:text/javascript;base64,${Buffer.from(outputText).toString('base64')}`)
+}
+
+const modulePath = resolve('src/locales/language.ts')
+
+test('Simplified Chinese browser locales select zh-cn', async () => {
+  const { preferredLanguage } = await importTsModule(modulePath)
+
+  for (const locale of ['zh-CN', 'zh-SG', 'zh-Hans', 'zh-Hans-CN']) {
+    assert.equal(preferredLanguage(locale), 'zh-cn')
+  }
+})
+
+test('Traditional Chinese browser locales keep the existing zh language', async () => {
+  const { preferredLanguage } = await importTsModule(modulePath)
+
+  for (const locale of ['zh-TW', 'zh-HK', 'zh-MO', 'zh-Hant', 'zh-Hant-TW', 'zh-Hant-CN']) {
+    assert.equal(preferredLanguage(locale), 'zh')
+  }
+})
+
+test('regional non-Chinese locales use their base language', async () => {
+  const { preferredLanguage } = await importTsModule(modulePath)
+
+  assert.equal(preferredLanguage('fr-CA'), 'fr')
+  assert.equal(preferredLanguage(''), 'en')
+})
+
+test('Simplified Chinese reuses the existing Chinese UI messages', async () => {
+  const { uiLocaleFor } = await importTsModule(modulePath)
+
+  assert.equal(uiLocaleFor('zh-cn'), 'zh')
+  assert.equal(uiLocaleFor('zh'), 'zh')
+  assert.equal(uiLocaleFor('de'), 'en')
+})

--- a/frontend/tests/language.test.mjs
+++ b/frontend/tests/language.test.mjs
@@ -50,3 +50,15 @@ test('Simplified Chinese reuses the existing Chinese UI messages', async () => {
   assert.equal(uiLocaleFor('zh'), 'zh')
   assert.equal(uiLocaleFor('de'), 'en')
 })
+
+test('bootstrap initializes Vue I18n with the normalized UI locale', async () => {
+  const source = await readFile(resolve('src/main.ts'), 'utf8')
+
+  assert.match(source, /locale:\s*currentLocale/)
+})
+
+test('language settings switch Vue I18n to the normalized UI locale', async () => {
+  const source = await readFile(resolve('src/components/SettingsForm.vue'), 'utf8')
+
+  assert.match(source, /locale\.value\s*=\s*uiLocale/)
+})


### PR DESCRIPTION
## Summary

- add `zh-cn` as a separate Simplified Chinese language option without modifying the existing `zh` card data
- reuse the existing Chinese UI messages while loading Simplified Chinese metadata from `cards_zh-cn.json`
- select `zh-cn` by default for new `zh-CN`, `zh-SG`, and `zh-Hans` browser profiles, while preserving `zh` for Traditional Chinese browser profiles and all existing saved preferences
- add a reproducible importer for `llwwbb/arkhamdb-json-data@5a50915b` and teach the slim-card build to accept language-region filenames

## Compatibility

The existing `frontend/public/cards_zh.json` file is unchanged. Users who already have `zh` in local storage keep the same card data, localized images, and ArkhamDB links.

The new `zh-cn` locale uses the existing Chinese application translations, a separate Simplified Chinese card dataset, and the normal English card images when no Simplified Chinese image is available.

The generated dataset contains all 5,929 current cards: 5,789 direct translations and 140 equivalent reprints, with no English text fallbacks and no unused source translations.

## Validation

- `npm test` (13 tests)
- `npm run tc`
- `npm run lint` (passes with existing warnings only)
- `npm run build`; verified `dist/cards/cards_zh-cn.json` and its gzip artifact are produced
- `node --test scripts/zh-cn/test/*.test.js` in the translation source repository (231 tests)
- verified `frontend/public/cards_zh.json` has no diff from `upstream/main`
