### PR TITLE
Add IF NOT EXISTS to CREATE INDEX in arkham_steps and create_log_entries migrations

### DIFF
--- a/migrations/deploy/arkham_steps.sql
+++ b/migrations/deploy/arkham_steps.sql
@@ -13,6 +13,6 @@ CREATE TABLE IF NOT EXISTS arkham_steps (
   step INTEGER NOT NULL
 );
 
-CREATE UNIQUE INDEX steps_game_step_idx ON arkham_steps(arkham_game_id, step);
+CREATE UNIQUE INDEX IF NOT EXISTS steps_game_step_idx ON arkham_steps(arkham_game_id, step);
 
 COMMIT;

--- a/migrations/deploy/create_log_entries.sql
+++ b/migrations/deploy/create_log_entries.sql
@@ -13,6 +13,6 @@ CREATE TABLE IF NOT EXISTS arkham_log_entries (
   created_at TIMESTAMP DEFAULT now()
 );
 
-CREATE INDEX log_entries_game_id ON arkham_log_entries(arkham_game_id);
+CREATE INDEX IF NOT EXISTS log_entries_game_id ON arkham_log_entries(arkham_game_id);
 
 COMMIT;


### PR DESCRIPTION
Newer migration files (arkham_achievements, arkham_ml_decisions, arkham_epic) already use this pattern consistently. The two older files were missing it, causing idempotent re-deploys to fail when the index already existed.