### PR TITLE
Fix decoding BothTarget game modifiers

### DIFF
--- a/frontend/src/arkham/types/Target.ts
+++ b/frontend/src/arkham/types/Target.ts
@@ -3,7 +3,7 @@ import { AbilityRef } from '@/arkham/types/Ability';
 import { Source, sourceDecoder } from '@/arkham/types/Source';
 import { v2Optional } from '@/arkham/parser'
 
-type TargetContents = string | { face: string, id: string } | { ability: AbilityRef }
+type TargetContents = string | { face: string, id: string } | { ability: AbilityRef } | [Target, Target]
 
 export type Target = {
   tag: string
@@ -26,6 +26,15 @@ const  targetContentsDecoder: JsonDecoder.Decoder<TargetContents> = JsonDecoder.
 
 export const targetDecoder: JsonDecoder.Decoder<Target> = JsonDecoder.lazy(() =>
   JsonDecoder.oneOf<Target>([
+    JsonDecoder.object<Target>(
+      {
+        tag: JsonDecoder.literal('BothTarget'),
+        contents: JsonDecoder.tuple([targetDecoder, targetDecoder], 'BothTargetContents'),
+        label: v2Optional(JsonDecoder.string()),
+        innerTag: v2Optional(JsonDecoder.string()),
+      },
+      'BothTarget'
+    ),
     JsonDecoder.object<Target>(
       {
         tag: JsonDecoder.literal('ProxyTarget'),

--- a/frontend/tests/targetDecoder.test.mjs
+++ b/frontend/tests/targetDecoder.test.mjs
@@ -1,0 +1,37 @@
+import assert from 'node:assert/strict'
+import { resolve } from 'node:path'
+import test from 'node:test'
+import { createServer } from 'vite'
+
+test('target decoder accepts a BothTarget with two nested targets', async (t) => {
+  const server = await createServer({
+    root: resolve('.'),
+    server: { middlewareMode: true },
+    appType: 'custom',
+    logLevel: 'silent',
+  })
+  t.after(() => server.close())
+
+  const { targetDecoder } = await server.ssrLoadModule('/src/arkham/types/Target.ts')
+  const payload = {
+    tag: 'BothTarget',
+    contents: [
+      {
+        tag: 'LocationTarget',
+        contents: '7042d939-b028-49bd-81d6-19b948ed35e5',
+      },
+      {
+        tag: 'LocationTarget',
+        contents: 'da2a4ea4-1503-4105-87cb-3c64e9e449da',
+      },
+    ],
+  }
+
+  const decoded = await targetDecoder.decodePromise(payload)
+
+  assert.equal(decoded.tag, payload.tag)
+  assert.deepEqual(
+    decoded.contents.map(({ tag, contents }) => ({ tag, contents })),
+    payload.contents,
+  )
+})


### PR DESCRIPTION
## Summary

- decode recursive `BothTarget` values in the frontend target decoder
- preserve both nested targets instead of rejecting the entire game payload
- add a regression test using the two-location payload that reproduced the failure

## Problem

`Sixth Sense (4)` can set a skill test target to `BothTarget`, and the backend serializes that valid target into the game's modifier map. The frontend `Target` decoder only accepted scalar, chaos-token, and ability contents, so it rejected the full `Game` payload when this target appeared. The game view then remained blank because initial loading never completed.

## Impact

Games containing a `BothTarget` modifier now load normally while retaining both underlying targets for future consumers.

## Validation

- `npm test` (5 tests passed)
- `npm run build`
- `npm run tc` reports only the existing unrelated errors in `ContinueCampaign.vue` and `GameRow.vue`; `Target.ts` is clean
