### PR TITLE
Fix Prismatic Phenomenon with Sixth Sense

### DIFF
--- a/backend/arkham-api/arkham-api.cabal
+++ b/backend/arkham-api/arkham-api.cabal
@@ -7370,6 +7370,7 @@ test-suite spec
       Arkham.Treachery.Cards.LegInjurySpec
       Arkham.Treachery.Cards.MysteriousChantingSpec
       Arkham.Treachery.Cards.ParanoiaSpec
+      Arkham.Treachery.Cards.PrismaticPhenomenonSpec
       Arkham.Treachery.Cards.PsychosisSpec
       Arkham.Treachery.Cards.PsychotropicSporesSpec
       Arkham.Treachery.Cards.RexsCurseSpec

--- a/backend/arkham-api/library/Arkham/Treachery/Cards/PrismaticPhenomenon.hs
+++ b/backend/arkham-api/library/Arkham/Treachery/Cards/PrismaticPhenomenon.hs
@@ -31,9 +31,19 @@ instance RunMessage PrismaticPhenomenon where
     UseThisAbility _ (isSource attrs -> True) 1 -> do
       whenJustM getSkillTestTarget \target ->
         withSkillTest \sid ->
-          skillTestModifier sid (attrs.ability 1) target (AlternateSuccessfullInvestigation $ toTarget attrs)
+          for_ (individualInvestigationTargets target) \target' ->
+            skillTestModifier
+              sid
+              (attrs.ability 1)
+              target'
+              (AlternateSuccessfullInvestigation $ toTarget attrs)
       pure t
     Successful (Action.Investigate, _) iid _ (isTarget attrs -> True) _ -> do
       toDiscardBy iid (attrs.ability 1) attrs
       pure t
     _ -> PrismaticPhenomenon <$> liftRunMessage msg attrs
+
+individualInvestigationTargets :: Target -> [Target]
+individualInvestigationTargets = \case
+  BothTarget left right -> individualInvestigationTargets left <> individualInvestigationTargets right
+  target -> [target]

--- a/backend/arkham-api/tests/Arkham/Treachery/Cards/PrismaticPhenomenonSpec.hs
+++ b/backend/arkham-api/tests/Arkham/Treachery/Cards/PrismaticPhenomenonSpec.hs
@@ -1,0 +1,37 @@
+module Arkham.Treachery.Cards.PrismaticPhenomenonSpec (spec) where
+
+import Arkham.Asset.Cards qualified as Assets
+import Arkham.Location.Types (revealedL)
+import Arkham.Matcher (TreacheryMatcher (TreacheryWithId))
+import Arkham.Treachery.Cards qualified as Treacheries
+import TestImport.New
+
+spec :: Spec
+spec = describe "Prismatic Phenomenon" $ do
+  it "replaces both Sixth Sense discoveries and discards itself" . gameTest $ \self -> do
+    withProp @"willpower" 5 self
+    (currentLocation, connectingLocation) <-
+      testConnectedLocations (revealedL .~ True) (revealedL .~ True)
+    updateProp @"shroud" 0 currentLocation
+    updateProp @"clues" 1 currentLocation
+    updateProp @"shroud" 0 connectingLocation
+    updateProp @"clues" 1 connectingLocation
+    self `moveTo` currentLocation
+
+    sixthSense <- self `putAssetIntoPlay` Assets.sixthSense4
+    prismaticPhenomenon <- self `putTreacheryIntoPlay` Treacheries.prismaticPhenomenon
+    setChaosTokens [Skull]
+
+    [investigateAction] <- self `getActionsFrom` sixthSense
+    self `useAbility` investigateAction
+    startSkillTest
+    chooseTarget connectingLocation
+    clickLabel "$label.useOriginalLocationsShroud"
+    applyResults
+    useForcedAbility
+    chooseFirstOption "resolve the first location's investigation result"
+
+    assertNone $ TreacheryWithId prismaticPhenomenon
+    currentLocation.clues `shouldReturn` 1
+    connectingLocation.clues `shouldReturn` 1
+    self.clues `shouldReturn` 0


### PR DESCRIPTION
## Summary

- apply Prismatic Phenomenon's alternate successful investigation modifier to each component of a multi-location skill test target
- add a regression test for Sixth Sense (4) resolving a symbol token against both the current and connected locations

## Root cause

Sixth Sense (4) changes the skill test target to a `BothTarget`. Prismatic Phenomenon attached its replacement modifier to that compound target, while successful investigations query modifiers on each individual location. As a result, neither location saw the replacement and the treachery was not discarded.

## Impact

Prismatic Phenomenon now replaces both clue discoveries and discards itself after a successful Sixth Sense (4) investigation, matching the behavior of a multi-location investigation.

## Validation

- `stack test arkham-api:spec`: 582 examples, 0 failures before syncing to the latest upstream `main`
- on the latest upstream `main`, the library and new spec module compile; the suite is currently blocked by an unrelated existing error in `tests/Entity/AnswerSpec.hs:36` (`getGame` is not in scope)
- `git diff --check upstream/main...HEAD`
