### PR TITLE
Fix .35 Winchester AutoFail damage

### DIFF
--- a/backend/arkham-api/arkham-api.cabal
+++ b/backend/arkham-api/arkham-api.cabal
@@ -7228,6 +7228,7 @@ test-suite spec
       Arkham.Asset.Assets.TheHungeringBlade1Spec
       Arkham.Asset.Assets.TheMuscleUnpracticedSpec
       Arkham.Asset.Assets.TheNecronomiconSpec
+      Arkham.Asset.Assets.ThirtyFiveWinchesterSpec
       Arkham.Asset.Assets.Tonys38LongColtSpec
       Arkham.Asset.Assets.TrueMagickReworkingReality5Spec
       Arkham.Asset.Assets.WendysAmuletSpec

--- a/backend/arkham-api/library/Arkham/Asset/Assets/ThirtyFiveWinchester.hs
+++ b/backend/arkham-api/library/Arkham/Asset/Assets/ThirtyFiveWinchester.hs
@@ -58,7 +58,7 @@ instance RunMessage ThirtyFiveWinchesterEffect where
             then
               token
                 <=~> IncludeTokenPool
-                  (IncludeSealed $ not_ $ oneOf [WithNegativeModifier, WithAutoFailModifier])
+                  (IncludeSealed WithNonNegativeModifier)
             else
               token <=~> IncludeTokenPool (IncludeSealed $ mapOneOf ChaosTokenFaceIs [PlusOne, Zero, ElderSign])
         when (isTarget sid attrs.target && valid) do

--- a/backend/arkham-api/library/Arkham/Asset/Assets/ThirtyFiveWinchester.hs
+++ b/backend/arkham-api/library/Arkham/Asset/Assets/ThirtyFiveWinchester.hs
@@ -55,7 +55,10 @@ instance RunMessage ThirtyFiveWinchesterEffect where
       withSkillTest \sid -> do
         valid <-
           if maybe False (== 1) attrs.metaInt
-            then token <=~> IncludeTokenPool (IncludeSealed $ not_ WithNegativeModifier)
+            then
+              token
+                <=~> IncludeTokenPool
+                  (IncludeSealed $ not_ $ oneOf [WithNegativeModifier, WithAutoFailModifier])
             else
               token <=~> IncludeTokenPool (IncludeSealed $ mapOneOf ChaosTokenFaceIs [PlusOne, Zero, ElderSign])
         when (isTarget sid attrs.target && valid) do

--- a/backend/arkham-api/library/Arkham/Game.hs
+++ b/backend/arkham-api/library/Arkham/Game.hs
@@ -5289,6 +5289,12 @@ instance Query ChaosTokenMatcher where
           ChaosTokenValue _ (NegativeModifier _) -> True
           ChaosTokenValue _ (DoubleNegativeModifier _) -> True
           _ -> False
+      WithNonNegativeModifier -> \t -> do
+        iid' <- toId <$> getActiveInvestigator
+        ChaosTokenValue _ modifier <- getChaosTokenValue iid' t.face ()
+        case modifier of
+          NoModifier -> pure False
+          _ -> maybe False (>= 0) <$> chaosTokenModifierToInt modifier
       WithAutoFailModifier -> \t -> do
         iid' <- toId <$> getActiveInvestigator
         getChaosTokenValue iid' t.face () <&> \case

--- a/backend/arkham-api/library/Arkham/Matcher/ChaosToken.hs
+++ b/backend/arkham-api/library/Arkham/Matcher/ChaosToken.hs
@@ -17,6 +17,7 @@ pattern NonSymbol = NotChaosToken IsSymbol
 
 data ChaosTokenMatcher
   = WithNegativeModifier
+  | WithNonNegativeModifier
   | WithAutoFailModifier
   | OnlyInBag ChaosTokenMatcher
   | ChaosTokenFaceIs ChaosTokenFace
@@ -58,6 +59,7 @@ instance ToDisplay ChaosTokenMatcher where
     OnlyInBag inner -> toDisplay inner
     ChaosTokenIs _ -> "Specific chaos token"
     WithNegativeModifier -> "Chaos token with negative modifier"
+    WithNonNegativeModifier -> "Chaos token with non-negative modifier"
     WithAutoFailModifier -> "Chaos token with auto fail modifier"
     ChaosTokenOriginalFaceIs face -> toDisplay face
     ChaosTokenFaceIs face -> toDisplay face

--- a/backend/arkham-api/tests/Arkham/Asset/Assets/ThirtyFiveWinchesterSpec.hs
+++ b/backend/arkham-api/tests/Arkham/Asset/Assets/ThirtyFiveWinchesterSpec.hs
@@ -1,7 +1,9 @@
 module Arkham.Asset.Assets.ThirtyFiveWinchesterSpec (spec) where
 
 import Arkham.Asset.Cards qualified as Assets
+import Arkham.Calculation
 import Arkham.Card.PlayerCard qualified as PlayerCard
+import Arkham.Enemy.Types qualified as Enemy
 import Arkham.Investigator.Cards (rolandBanks)
 import Arkham.Matcher
 import Arkham.Taboo.Types
@@ -33,3 +35,26 @@ spec = describe ".35 Winchester" $ do
     applyAllDamage
 
     teammate.damage `shouldReturn` 1
+
+  it "does not deal +2 damage when the token has no modifier" . gameTest $ \self -> do
+    winchesterCard <-
+      genPlayerCardWith Assets.thirtyFiveWinchester
+        $ PlayerCard.setTaboo (Just TabooList18)
+        . setPlayerCardOwner self.id
+    run $ PutCardIntoPlay self.id (toCard winchesterCard) Nothing NoPayment []
+    winchester <- selectJust $ assetIs Assets.thirtyFiveWinchester
+
+    enemy <- testEnemyWith (Enemy.healthL ?~ Fixed 4)
+    location <- testLocation
+    setChaosTokens [ElderThing]
+    enemy `spawnAt` location
+    self `moveTo` location
+
+    [doFight] <- self `getActionsFrom` winchester
+    self `useAbility` doFight
+    chooseTarget enemy
+    run $ ForceChaosTokenDraw ElderThing
+    applyResults
+    applyAllDamage
+
+    enemy.damage `shouldReturn` 1

--- a/backend/arkham-api/tests/Arkham/Asset/Assets/ThirtyFiveWinchesterSpec.hs
+++ b/backend/arkham-api/tests/Arkham/Asset/Assets/ThirtyFiveWinchesterSpec.hs
@@ -1,0 +1,35 @@
+module Arkham.Asset.Assets.ThirtyFiveWinchesterSpec (spec) where
+
+import Arkham.Asset.Cards qualified as Assets
+import Arkham.Card.PlayerCard qualified as PlayerCard
+import Arkham.Investigator.Cards (rolandBanks)
+import Arkham.Matcher
+import Arkham.Taboo.Types
+import TestImport.New
+
+spec :: Spec
+spec = describe ".35 Winchester" $ do
+  it "does not deal +2 damage when a Curse token reveals the AutoFail token" . gameTest $ \self -> do
+    winchesterCard <-
+      genPlayerCardWith Assets.thirtyFiveWinchester
+        $ PlayerCard.setTaboo (Just TabooList18)
+        . setPlayerCardOwner self.id
+    run $ PutCardIntoPlay self.id (toCard winchesterCard) Nothing NoPayment []
+    winchester <- selectJust $ assetIs Assets.thirtyFiveWinchester
+
+    teammate <- addInvestigator rolandBanks
+    enemy <- testEnemy
+    location <- testLocation
+    setChaosTokens [CurseToken, AutoFail]
+    teammate `moveTo` location
+    enemy `spawnAt` location
+    self `moveTo` location
+
+    [doFight] <- self `getActionsFrom` winchester
+    self `useAbility` doFight
+    chooseTarget enemy
+    run $ ForceChaosTokenDraw CurseToken
+    applyResults
+    applyAllDamage
+
+    teammate.damage `shouldReturn` 1


### PR DESCRIPTION
## Summary

- prevent the taboo `.35 Winchester` from treating an AutoFail modifier as a non-negative token result
- add a regression test for a Curse token followed by AutoFail while attacking an enemy engaged with another investigator

## Root cause

The taboo matcher only excluded `WithNegativeModifier`, so `AutoFailModifier` still qualified for the extra 2 damage. When the attack failed against an enemy engaged with another investigator, the failed-attack damage redirect therefore assigned all 3 damage to that investigator.

## User impact

In this sequence, the engaged investigator now takes only the attack's base 1 damage.

## Verification

- `stack test arkham-api:spec --fast --test-arguments=--match=Winchester`
- `1 example, 0 failures`
