### PR TITLE
Fix split-card translation lookup

### DIFF
--- a/frontend/src/stores/dbCards.ts
+++ b/frontend/src/stores/dbCards.ts
@@ -58,7 +58,9 @@ export const useDbCardStore = defineStore("dbCards", {
         void this.initDbCards()
       }
 
-      return this.dbCardsIndex.get(code) ?? null
+      // ArkhamDB stores some split-card fronts with an "a" suffix, while the
+      // game runtime refers to the same front using the unsuffixed code.
+      return this.dbCardsIndex.get(code) ?? this.dbCardsIndex.get(`${code}a`) ?? null
     },
 
     getCardName(cardTitle: string, typeCode: string = ""): string {

--- a/frontend/tests/dbCards.test.mjs
+++ b/frontend/tests/dbCards.test.mjs
@@ -1,0 +1,38 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { fileURLToPath, URL } from 'node:url'
+
+import { createPinia, setActivePinia } from 'pinia'
+import { createServer } from 'vite'
+
+test('unsuffixed runtime codes resolve split-card front translations', async (t) => {
+  const server = await createServer({
+    root: fileURLToPath(new URL('..', import.meta.url)),
+    appType: 'custom',
+    logLevel: 'silent',
+    server: { middlewareMode: true, hmr: false },
+  })
+  t.after(() => server.close())
+
+  const { useDbCardStore } = await server.ssrLoadModule('/src/stores/dbCards.ts')
+  const dagonFront = { code: '07330a', name: '达贡', real_name: 'Dagon' }
+  const dagonBack = { code: '07330b', name: '达贡', real_name: 'Dagon' }
+  const hydraFront = { code: '07331a', name: '海德拉', real_name: 'Hydra' }
+  const hydraBack = { code: '07331b', name: '海德拉', real_name: 'Hydra' }
+  const originalFetch = globalThis.fetch
+  globalThis.fetch = async () => ({
+    json: async () => [dagonFront, dagonBack, hydraFront, hydraBack],
+  })
+  t.after(() => {
+    globalThis.fetch = originalFetch
+  })
+
+  setActivePinia(createPinia())
+  const store = useDbCardStore()
+  await store.fetchDbCards('en')
+
+  assert.equal(store.getDbCard('07330')?.code, dagonFront.code)
+  assert.equal(store.getDbCard('07330b')?.code, dagonBack.code)
+  assert.equal(store.getDbCard('07331')?.code, hydraFront.code)
+  assert.equal(store.getDbCard('07331b')?.code, hydraBack.code)
+})


### PR DESCRIPTION
## Summary

- fall back to an `a`-suffixed ArkhamDB card when an unsuffixed runtime code has no exact match
- add a store-level regression test for the front and back sides of Dagon (`07330`) and Hydra (`07331`)

## Why

ArkhamDB represents these split cards as `07330a`/`07330b` and `07331a`/`07331b`, while the game runtime uses `07330` and `07331` for the front sides. The card store only performed exact lookups, so the hover overlay could not find the localized front-side records.

Exact matches remain preferred, which preserves existing unsuffixed cards and keeps `b`-side lookups unchanged.

## Impact

Localized hover text now appears for split-card fronts that use unsuffixed runtime codes. The fix is language-independent.

## Validation

- `npm test` — 22 tests passed
- `npm run tc`
- ESLint on the changed source and test
- production `zh-cn` data lookup for `07330`, `07330b`, `07331`, and `07331b`
