### PR TITLE
Pulse the clickable damage/horror tokens

### DIFF
--- a/frontend/src/arkham/components/PoolItem.vue
+++ b/frontend/src/arkham/components/PoolItem.vue
@@ -131,6 +131,36 @@ const image = computed(() => {
       drop-shadow(-1px 0 0 var(--select))
       drop-shadow(0 1px 0 var(--select))
       drop-shadow(0 -1px 0 var(--select));
+    animation: token-attention-pulse 0.9s ease-in-out infinite alternate;
+  }
+}
+
+/* Pending damage/horror assignments block the turn, so their tokens tick
+   between the base outline and a brighter, slightly enlarged glow. */
+@keyframes token-attention-pulse {
+  from {
+    filter:
+      drop-shadow(1px 0 0 var(--select))
+      drop-shadow(-1px 0 0 var(--select))
+      drop-shadow(0 1px 0 var(--select))
+      drop-shadow(0 -1px 0 var(--select));
+    transform: scale(1);
+  }
+  to {
+    filter:
+      drop-shadow(1px 0 0 var(--select))
+      drop-shadow(-1px 0 0 var(--select))
+      drop-shadow(0 1px 0 var(--select))
+      drop-shadow(0 -1px 0 var(--select))
+      drop-shadow(0 0 5px var(--select))
+      brightness(1.35);
+    transform: scale(1.1);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .health--can-interact img, .sanity--can-interact img {
+    animation: none;
   }
 }
 </style>


### PR DESCRIPTION
A pending damage/horror assignment blocks the turn (End turn stays disabled), but its only cue was a static magenta outline on the token, which is easy to miss. In play this looked like a stuck game: with Frozen in Fear, entering the Attic on the last action left End turn greyed out and the pending horror token went unnoticed.

This animates the outline on the clickable health/sanity tokens (investigator and asset soak both go through PoolItem.vue) with a brightness/scale tick so the pending assignment stands out. The animation is disabled under prefers-reduced-motion, keeping today's static outline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)