### PR TITLE
Custom card sets, and importing a card pool from arkham.build

### DIFF
--- a/backend/arkham-api/arkham-api.cabal
+++ b/backend/arkham-api/arkham-api.cabal
@@ -30,6 +30,7 @@ library
       Api.Handler.Arkham.Admin.Metrics
       Api.Handler.Arkham.Cards
       Api.Handler.Arkham.CustomCards
+      Api.Handler.Arkham.CustomCardSets
       Api.Handler.Arkham.Decks
       Api.Handler.Arkham.Events
       Api.Handler.Arkham.Game.Bug
@@ -8144,6 +8145,7 @@ library
       Entity.Arkham.Achievement
       Entity.Arkham.ArkhamDBDecklist
       Entity.Arkham.CustomCard
+      Entity.Arkham.CustomCardSet
       Entity.Arkham.Deck
       Entity.Arkham.DeckOverlay
       Entity.Arkham.Epic

--- a/backend/arkham-api/config/routes
+++ b/backend/arkham-api/config/routes
@@ -18,9 +18,12 @@
       /schema ApiV1ArkhamSchemaR GET
       /custom-cards ApiV1ArkhamCustomCardsP:
         / ApiV1ArkhamCustomCardsR GET POST
-        !/import ApiV1ArkhamCustomCardsImportR POST
         !/art ApiV1ArkhamCustomCardsArtR POST
         /#ArkhamCustomCardId ApiV1ArkhamCustomCardR DELETE
+      /custom-card-sets ApiV1ArkhamCustomCardSetsP:
+        / ApiV1ArkhamCustomCardSetsR GET POST
+        !/import ApiV1ArkhamCustomCardSetsImportR POST
+        /#ArkhamCustomCardSetId ApiV1ArkhamCustomCardSetR PUT DELETE
       /homebrew/cards ApiV1ArkhamHomebrewCardsR GET
       /card/#CardCode ApiV1ArkhamCardR GET
       /investigators ApiV1ArkhamInvestigatorsR GET

--- a/backend/arkham-api/library/Api/Handler/Arkham/CustomCardSets.hs
+++ b/backend/arkham-api/library/Api/Handler/Arkham/CustomCardSets.hs
@@ -1,0 +1,202 @@
+module Api.Handler.Arkham.CustomCardSets (
+  getApiV1ArkhamCustomCardSetsR,
+  postApiV1ArkhamCustomCardSetsR,
+  postApiV1ArkhamCustomCardSetsImportR,
+  putApiV1ArkhamCustomCardSetR,
+  deleteApiV1ArkhamCustomCardSetR,
+) where
+
+import Api.Handler.Arkham.CustomCards (ownedCardSet, saveCardInSet, stampSetName)
+import Arkham.Card.CustomCard (CustomCard (..))
+import Data.Aeson.Types (parseMaybe)
+import Data.Text qualified as T
+import Data.Time.Clock
+import Import hiding ((==.))
+import Import qualified as P
+
+{- | A set as the builder sees it: what it is called, where it came from, and how
+much is in it. The count is what makes the sidebar useful, and is cheaper to
+total here than to have the client tally a library it may not have loaded.
+-}
+data CustomCardSetResponse = CustomCardSetResponse
+  { customCardSetResponseId :: ArkhamCustomCardSetId
+  , customCardSetResponseName :: Text
+  , customCardSetResponseSourceCode :: Maybe Text
+  , customCardSetResponseCardCount :: Int
+  , customCardSetResponseUpdatedAt :: UTCTime
+  }
+  deriving stock Generic
+
+instance ToJSON CustomCardSetResponse where
+  toJSON = genericToJSON $ aesonOptions $ Just "customCardSetResponse"
+  toEncoding = genericToEncoding $ aesonOptions $ Just "customCardSetResponse"
+
+data CustomCardSetImportResponse = CustomCardSetImportResponse
+  { customCardSetImportResponseSet :: CustomCardSetResponse
+  , customCardSetImportResponseCards :: [Entity ArkhamCustomCard]
+  }
+  deriving stock Generic
+
+instance ToJSON CustomCardSetImportResponse where
+  toJSON = genericToJSON $ aesonOptions $ Just "customCardSetImportResponse"
+  toEncoding = genericToEncoding $ aesonOptions $ Just "customCardSetImportResponse"
+
+newtype SetNamePost = SetNamePost {setNameName :: Text}
+  deriving stock Generic
+
+instance FromJSON SetNamePost where
+  parseJSON = genericParseJSON $ aesonOptions $ Just "setName"
+
+data ImportSetPost = ImportSetPost
+  { importSetName :: Text
+  , importSetSourceCode :: Maybe Text
+  , importSetCards :: [CustomCard]
+  }
+  deriving stock Generic
+
+instance FromJSON ImportSetPost where
+  parseJSON = genericParseJSON $ aesonOptions $ Just "importSet"
+
+-- | A set with nothing in it is still a set; a set with no name is a mistake.
+requireName :: Text -> Handler Text
+requireName raw = do
+  let name = T.strip raw
+  when (T.null name) $ invalidArgs ["A set needs a name"]
+  pure name
+
+setResponse :: Entity ArkhamCustomCardSet -> Handler CustomCardSetResponse
+setResponse (Entity setId row) = do
+  cardCount <- runDB $ P.count [ArkhamCustomCardCustomCardSetId P.==. setId]
+  pure
+    $ CustomCardSetResponse
+      { customCardSetResponseId = setId
+      , customCardSetResponseName = arkhamCustomCardSetName row
+      , customCardSetResponseSourceCode = arkhamCustomCardSetSourceCode row
+      , customCardSetResponseCardCount = cardCount
+      , customCardSetResponseUpdatedAt = arkhamCustomCardSetUpdatedAt row
+      }
+
+getApiV1ArkhamCustomCardSetsR :: Handler [CustomCardSetResponse]
+getApiV1ArkhamCustomCardSetsR = do
+  userId <- getRequestUserId
+  sets <-
+    runDB
+      $ P.selectList [ArkhamCustomCardSetUserId P.==. userId] [P.Asc ArkhamCustomCardSetName]
+  traverse setResponse sets
+
+{- | Make a set. Asking twice for the same name gives you back the one you have
+rather than refusing: the client is trying to end up with a set by that name,
+and it already has one.
+-}
+postApiV1ArkhamCustomCardSetsR :: Handler CustomCardSetResponse
+postApiV1ArkhamCustomCardSetsR = do
+  userId <- getRequestUserId
+  SetNamePost {setNameName} <- requireCheckJsonBody
+  name <- requireName setNameName
+  now <- liftIO getCurrentTime
+  existing <- runDB $ P.getBy (UniqueUserCustomCardSetName userId name)
+  case existing of
+    Just found -> setResponse found
+    Nothing -> do
+      let row = ArkhamCustomCardSet userId name Nothing now now
+      setId <- runDB $ P.insert row
+      setResponse $ Entity setId row
+
+{- | Rename, and carry the new name into the cards.
+
+The copy each card holds is only a copy, but it is the one anything looking at a
+def alone will read -- the deck overlay, the card picker, a card exported on its
+own -- so leaving it behind would show the old name everywhere but here.
+-}
+putApiV1ArkhamCustomCardSetR :: ArkhamCustomCardSetId -> Handler CustomCardSetResponse
+putApiV1ArkhamCustomCardSetR setId = do
+  userId <- getRequestUserId
+  SetNamePost {setNameName} <- requireCheckJsonBody
+  name <- requireName setNameName
+  row <- ownedCardSet userId setId
+  now <- liftIO getCurrentTime
+
+  clash <- runDB $ P.getBy (UniqueUserCustomCardSetName userId name)
+  case clash of
+    Just (Entity clashId _) | clashId /= setId -> invalidArgs ["You already have a set with that name"]
+    _ -> pure ()
+
+  cards <- runDB $ P.selectList [ArkhamCustomCardCustomCardSetId P.==. setId] []
+  runDB do
+    P.update setId [ArkhamCustomCardSetName P.=. name, ArkhamCustomCardSetUpdatedAt P.=. now]
+    for_ cards \(Entity cardId card) ->
+      for_ (parseMaybe parseJSON (arkhamCustomCardDef card)) \def ->
+        P.update
+          cardId
+          [ ArkhamCustomCardDef P.=. toJSON (stampSetName name def)
+          , ArkhamCustomCardUpdatedAt P.=. now
+          ]
+
+  setResponse
+    $ Entity setId
+    $ row {arkhamCustomCardSetName = name, arkhamCustomCardSetUpdatedAt = now}
+
+{- | Deleting a set deletes what is in it.
+
+That is the point of it being a set: importing a hundred and fifty cards and
+changing your mind is one decision, not a hundred and fifty.
+-}
+deleteApiV1ArkhamCustomCardSetR :: ArkhamCustomCardSetId -> Handler ()
+deleteApiV1ArkhamCustomCardSetR setId = do
+  userId <- getRequestUserId
+  void $ ownedCardSet userId setId
+  runDB do
+    -- The foreign key cascades, but the cards are deleted explicitly so this
+    -- does not depend on the constraint being in place in a given database.
+    P.deleteWhere [ArkhamCustomCardCustomCardSetId P.==. setId]
+    P.delete setId
+
+{- | Import a whole set at once, replacing one already here.
+
+A set that has been imported before is matched on the pack id it came with, or
+failing that its name, and its contents are replaced outright rather than merged
+into: the file is the set as it now stands, so a card the file no longer has is
+a card the set no longer has.
+-}
+postApiV1ArkhamCustomCardSetsImportR :: Handler CustomCardSetImportResponse
+postApiV1ArkhamCustomCardSetsImportR = do
+  userId <- getRequestUserId
+  ImportSetPost {importSetName, importSetSourceCode, importSetCards} <- requireCheckJsonBody
+  name <- requireName importSetName
+  now <- liftIO getCurrentTime
+
+  existing <- findSet userId name importSetSourceCode
+  setId <- case existing of
+    Just (Entity foundId _) -> do
+      runDB do
+        P.update
+          foundId
+          [ ArkhamCustomCardSetName P.=. name
+          , ArkhamCustomCardSetSourceCode P.=. importSetSourceCode
+          , ArkhamCustomCardSetUpdatedAt P.=. now
+          ]
+        P.deleteWhere [ArkhamCustomCardCustomCardSetId P.==. foundId]
+      pure foundId
+    Nothing -> runDB $ P.insert $ ArkhamCustomCardSet userId name importSetSourceCode now now
+
+  cards <- traverse (saveCardInSet userId setId name now) importSetCards
+  row <- runDB $ get404 setId
+  response <- setResponse (Entity setId row)
+  pure $ CustomCardSetImportResponse response cards
+
+{- | The set an import means: the one from the same pack, else the one by that
+name. A set built here has no pack id, so a pack cannot quietly adopt one unless
+the names already match -- which is the case where replacing is what was meant.
+-}
+findSet :: UserId -> Text -> Maybe Text -> Handler (Maybe (Entity ArkhamCustomCardSet))
+findSet userId name sourceCode = do
+  bySource <- case sourceCode of
+    Nothing -> pure Nothing
+    Just code ->
+      runDB
+        $ P.selectFirst
+          [ArkhamCustomCardSetUserId P.==. userId, ArkhamCustomCardSetSourceCode P.==. Just code]
+          []
+  case bySource of
+    Just found -> pure $ Just found
+    Nothing -> runDB $ P.getBy (UniqueUserCustomCardSetName userId name)

--- a/backend/arkham-api/library/Api/Handler/Arkham/CustomCardSets.hs
+++ b/backend/arkham-api/library/Api/Handler/Arkham/CustomCardSets.hs
@@ -13,6 +13,7 @@ import Data.Text qualified as T
 import Data.Time.Clock
 import Import hiding ((==.))
 import Import qualified as P
+import Json hiding (Success)
 
 {- | A set as the builder sees it: what it is called, where it came from, and how
 much is in it. The count is what makes the sidebar useful, and is cheaper to

--- a/backend/arkham-api/library/Api/Handler/Arkham/CustomCards.hs
+++ b/backend/arkham-api/library/Api/Handler/Arkham/CustomCards.hs
@@ -1,10 +1,12 @@
 module Api.Handler.Arkham.CustomCards (
   getApiV1ArkhamCustomCardsR,
   postApiV1ArkhamCustomCardsR,
-  postApiV1ArkhamCustomCardsImportR,
   postApiV1ArkhamCustomCardsArtR,
   deleteApiV1ArkhamCustomCardR,
   registerUserCustomCards,
+  ownedCardSet,
+  saveCardInSet,
+  stampSetName,
 ) where
 
 import Amazonka
@@ -21,7 +23,7 @@ import Arkham.Card.CustomCard (
   sanitizeCustomCardCode,
  )
 import Crypto.Hash.SHA256 qualified as SHA256
-import Data.Aeson.Types (parseMaybe)
+import Data.Aeson.Types (parseMaybe, withObject, (.:))
 import Data.ByteString.Base16 qualified as B16
 import Data.ByteString.Base64 qualified as B64
 import Data.ByteString.Lazy qualified as BSL
@@ -55,15 +57,38 @@ normalizeCard card = do
   let def = (customCardDef card) {cdCardCode = cardCode, cdArt = unCardCode cardCode}
   pure (cardCode, card {customCardDef = def})
 
-saveCard :: UserId -> UTCTime -> CustomCard -> Handler (Entity ArkhamCustomCard)
-saveCard userId now card0 = do
+{- | The set at this id, if it is the requesting user's.
+
+Lives here rather than beside the set handlers because saving a card is what
+most needs it, and because the set handlers already depend on this module --
+the other direction would be a cycle.
+-}
+ownedCardSet :: UserId -> ArkhamCustomCardSetId -> Handler ArkhamCustomCardSet
+ownedCardSet userId setId = do
+  set <- runDB $ get404 setId
+  unless (arkhamCustomCardSetUserId set == userId) $ permissionDenied "Not your card set"
+  pure set
+
+{- | The set's name, written into the card's own def.
+
+The set row is what a card belongs to; this is the copy that travels with the
+card, for everything that only ever sees a def -- the deck overlay, the card
+picker, a card exported on its own.
+-}
+stampSetName :: Text -> CardDef -> CardDef
+stampSetName name def = def {cdMeta = Map.insert "set" (String name) (cdMeta def)}
+
+saveCardInSet
+  :: UserId -> ArkhamCustomCardSetId -> Text -> UTCTime -> CustomCard -> Handler (Entity ArkhamCustomCard)
+saveCardInSet userId setId setName now card0 = do
   (cardCode, card') <- normalizeCard card0
   art <- traverse (hostArt userId) (customCardArt card')
-  def <- hostDefArt userId (customCardDef card')
+  def <- hostDefArt userId (stampSetName setName (customCardDef card'))
   let card = card' {customCardArt = art, customCardDef = def}
   let row =
         ArkhamCustomCard
           userId
+          setId
           (unCardCode cardCode)
           (toJSON (customCardDef card))
           (customCardArt card)
@@ -74,7 +99,8 @@ saveCard userId now card0 = do
       Just (Entity rowId existing) -> do
         P.update
           rowId
-          [ ArkhamCustomCardDef P.=. toJSON (customCardDef card)
+          [ ArkhamCustomCardCustomCardSetId P.=. setId
+          , ArkhamCustomCardDef P.=. toJSON (customCardDef card)
           , ArkhamCustomCardArt P.=. customCardArt card
           , ArkhamCustomCardUpdatedAt P.=. now
           ]
@@ -82,7 +108,8 @@ saveCard userId now card0 = do
         pure
           $ Entity rowId
           $ existing
-            { arkhamCustomCardDef = toJSON (customCardDef card)
+            { arkhamCustomCardCustomCardSetId = setId
+            , arkhamCustomCardDef = toJSON (customCardDef card)
             , arkhamCustomCardArt = customCardArt card
             , arkhamCustomCardUpdatedAt = now
             }
@@ -90,27 +117,26 @@ saveCard userId now card0 = do
         rowId <- P.insert row
         pure $ Entity rowId row
 
+-- | A card is always saved into a set, so the set it goes in comes with it.
+data SaveCardPost = SaveCardPost
+  { saveCardPostSetId :: ArkhamCustomCardSetId
+  , saveCardPostCard :: CustomCard
+  }
+
+instance FromJSON SaveCardPost where
+  parseJSON v =
+    withObject
+      "SaveCardPost"
+      (\o -> SaveCardPost <$> (ArkhamCustomCardSetKey <$> o .: "setId") <*> parseJSON v)
+      v
+
 postApiV1ArkhamCustomCardsR :: Handler (Entity ArkhamCustomCard)
 postApiV1ArkhamCustomCardsR = do
   userId <- getRequestUserId
-  card <- requireCheckJsonBody
+  SaveCardPost {saveCardPostSetId, saveCardPostCard} <- requireCheckJsonBody
+  set <- ownedCardSet userId saveCardPostSetId
   now <- liftIO getCurrentTime
-  saveCard userId now card
-
-newtype CustomCardImport = CustomCardImport {cards :: [CustomCard]}
-  deriving stock Generic
-  deriving anyclass FromJSON
-
-{- | Bulk upsert, for importing an exported file. Cards keep the codes they were
-exported with, so re-importing your own export updates those cards rather than
-duplicating them.
--}
-postApiV1ArkhamCustomCardsImportR :: Handler [Entity ArkhamCustomCard]
-postApiV1ArkhamCustomCardsImportR = do
-  userId <- getRequestUserId
-  CustomCardImport {cards} <- requireCheckJsonBody
-  now <- liftIO getCurrentTime
-  traverse (saveCard userId now) cards
+  saveCardInSet userId saveCardPostSetId (arkhamCustomCardSetName set) now saveCardPostCard
 
 deleteApiV1ArkhamCustomCardR :: ArkhamCustomCardId -> Handler ()
 deleteApiV1ArkhamCustomCardR cardId = do

--- a/backend/arkham-api/library/Application.hs
+++ b/backend/arkham-api/library/Application.hs
@@ -88,6 +88,7 @@ import Api.Handler.Arkham.Achievements
 import Api.Handler.Arkham.Admin.Metrics
 import Api.Handler.Arkham.Cards
 import Api.Handler.Arkham.CustomCards
+import Api.Handler.Arkham.CustomCardSets
 import Api.Handler.Arkham.Decks
 import Api.Handler.Arkham.Events
 import Api.Handler.Arkham.Game.Bug

--- a/backend/arkham-api/library/Entity/Arkham/CustomCard.hs
+++ b/backend/arkham-api/library/Entity/Arkham/CustomCard.hs
@@ -10,6 +10,9 @@ import Data.Time.Clock
 import Data.UUID (UUID)
 import Database.Persist.TH
 import Entity
+-- Brought into scope for `discoverEntities` below: the set this card belongs to
+-- cannot be referenced without its entity def being visible here.
+import Entity.Arkham.CustomCardSet
 import Entity.User
 import Json
 import Orphans ()
@@ -22,6 +25,8 @@ it outlives any one game and follows them between browsers.
 game refers to it by, so it is the identity here too -- saving an edit replaces
 the row rather than adding one. @art@ is a URL or an inlined data URI and is
 stored apart from @def@ so listing the library does not have to carry it.
+
+Every card belongs to a set, and goes when the set goes.
 -}
 mkEntity
   $(discoverEntities)
@@ -29,6 +34,7 @@ mkEntity
 ArkhamCustomCard sql=arkham_custom_cards
   Id UUID default=uuid_generate_v4()
   userId UserId OnDeleteCascade
+  customCardSetId ArkhamCustomCardSetId OnDeleteCascade
   cardCode Text
   def Value
   art Text Maybe

--- a/backend/arkham-api/library/Entity/Arkham/CustomCardSet.hs
+++ b/backend/arkham-api/library/Entity/Arkham/CustomCardSet.hs
@@ -1,0 +1,46 @@
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module Entity.Arkham.CustomCardSet (
+  module Entity.Arkham.CustomCardSet,
+) where
+
+import Data.Time.Clock
+import Data.UUID (UUID)
+import Database.Persist.TH
+import Entity
+import Entity.User
+import Json
+import Orphans ()
+import Relude
+
+{- | A named collection of custom cards: the unit you build, export, and hand to
+someone else.
+
+Grouping used to be a string each card carried in its own def, which meant a set
+existed only as far as every one of its cards agreed on the spelling, and
+throwing one away meant deleting its cards one at a time. A set is a row now, so
+it can be renamed in one place and deleted with what is in it.
+
+@sourceCode@ is the id of the pack an imported set came from (arkham.build gives
+one), so importing that pack again replaces this set rather than making a second
+copy of it. A set built here has none.
+-}
+mkEntity
+  $(discoverEntities)
+  [persistLowerCase|
+ArkhamCustomCardSet sql=arkham_custom_card_sets
+  Id UUID default=uuid_generate_v4()
+  userId UserId OnDeleteCascade
+  name Text
+  sourceCode Text Maybe
+  createdAt UTCTime
+  updatedAt UTCTime
+  UniqueUserCustomCardSetName userId name
+  deriving Generic Show
+|]
+
+instance ToJSON ArkhamCustomCardSet where
+  toJSON = genericToJSON $ aesonOptions $ Just "arkhamCustomCardSet"
+  toEncoding = genericToEncoding $ aesonOptions $ Just "arkhamCustomCardSet"

--- a/backend/arkham-api/library/Model.hs
+++ b/backend/arkham-api/library/Model.hs
@@ -12,6 +12,7 @@ import Database.Persist.Postgresql.JSON ()
 import Entity.Arkham.Achievement as X
 import Entity.Arkham.ArkhamDBDecklist as X
 import Entity.Arkham.CustomCard as X
+import Entity.Arkham.CustomCardSet as X
 import Entity.Arkham.Deck as X
 import Entity.Arkham.Epic as X
 import Entity.Arkham.Game as X

--- a/frontend/src/arkham/api.ts
+++ b/frontend/src/arkham/api.ts
@@ -129,21 +129,83 @@ export const fetchTraits = async (): Promise<[string, string][]> => {
   return data
 }
 
-export type StoredCustomCard = { id: string; cardCode: string; def: any; art: string | null; updatedAt: string }
+export type StoredCustomCard = {
+  id: string
+  setId: string
+  cardCode: string
+  def: any
+  art: string | null
+  updatedAt: string
+}
+
+/* A set is what a card belongs to: the unit you build, export, and hand to
+ * someone else. Every card has one. */
+export type StoredCustomCardSet = {
+  id: string
+  name: string
+  // The pack id an imported set came from, so re-importing that pack replaces
+  // this set rather than making a second copy of it. Null for a set made here.
+  sourceCode: string | null
+  cardCount: number
+  updatedAt: string
+}
+
+export const fetchCustomCardSets = async (): Promise<StoredCustomCardSet[]> => {
+  const { data } = await api.get('arkham/custom-card-sets')
+  return data
+}
+
+export const createCustomCardSet = async (name: string): Promise<StoredCustomCardSet> => {
+  const { data } = await api.post('arkham/custom-card-sets', { name })
+  return data
+}
+
+export const renameCustomCardSet = async (id: string, name: string): Promise<StoredCustomCardSet> => {
+  const { data } = await api.put(`arkham/custom-card-sets/${id}`, { name })
+  return data
+}
+
+// Takes the set's cards with it.
+export const deleteCustomCardSet = async (id: string): Promise<void> => {
+  await api.delete(`arkham/custom-card-sets/${id}`)
+}
+
+/* One call, one set: whatever the set held before is replaced by exactly these
+ * cards, so importing a corrected pack cannot leave the cards it dropped
+ * behind. Matched to an existing set by `sourceCode` when there is one, by
+ * name otherwise. */
+export const importCustomCardSet = async (payload: {
+  name: string
+  sourceCode: string | null
+  cards: { def: any; art: string | null }[]
+}): Promise<{ set: StoredCustomCardSet; cards: StoredCustomCard[] }> => {
+  const { data } = await api.post('arkham/custom-card-sets/import', payload)
+  return { set: data.set, cards: data.cards.map(toStoredCustomCard) }
+}
+
+/* A card row names its set the way the entity spells the field; `setId` is what
+ * it is called here. */
+const toStoredCustomCard = (row: any): StoredCustomCard => ({
+  id: row.id,
+  setId: row.customCardSetId,
+  cardCode: row.cardCode,
+  def: row.def,
+  art: row.art,
+  updatedAt: row.updatedAt,
+})
 
 export const fetchCustomCardLibrary = async (): Promise<StoredCustomCard[]> => {
   const { data } = await api.get('arkham/custom-cards')
-  return data.map((row: any) => ({ id: row.id, ...row }))
+  return data.map(toStoredCustomCard)
 }
 
-export const saveCustomCard = async (card: { def: any; art: string | null }): Promise<StoredCustomCard> => {
+export const saveCustomCard = async (card: {
+  setId: string
+  def: any
+  art: string | null
+}): Promise<StoredCustomCard> => {
   const { data } = await api.post('arkham/custom-cards', card)
-  return { id: data.id, ...data }
-}
-
-export const importCustomCards = async (cards: { def: any; art: string | null }[]): Promise<StoredCustomCard[]> => {
-  const { data } = await api.post('arkham/custom-cards/import', { cards })
-  return data.map((row: any) => ({ id: row.id, ...row }))
+  return toStoredCustomCard(data)
 }
 
 export const deleteCustomCard = async (id: string): Promise<void> => {

--- a/frontend/src/arkham/arkhamBuildImport.ts
+++ b/frontend/src/arkham/arkhamBuildImport.ts
@@ -91,8 +91,16 @@ const setIf = (obj: Record<string, any>, key: string, value: unknown) => {
 }
 
 /* Accepts a full arkham.build card-pool export ({meta, data:{cards:[...]}}),
- * a bare {cards:[...]}, or a single card object on its own. */
-export function parseArkhamBuildCards(raw: string): { packName: string | null; cards: any[] } {
+ * a bare {cards:[...]}, or a single card object on its own.
+ *
+ * `packCode` is the pack's own id, kept so that importing a corrected version of
+ * the same pack later replaces the set it made rather than making a second one
+ * beside it -- which a rename of the pack would otherwise cause. */
+export function parseArkhamBuildCards(raw: string): {
+  packName: string | null
+  packCode: string | null
+  cards: any[]
+} {
   const parsed = JSON.parse(raw)
   const cards: any[] = Array.isArray(parsed?.data?.cards)
     ? parsed.data.cards
@@ -101,7 +109,11 @@ export function parseArkhamBuildCards(raw: string): { packName: string | null; c
       : parsed?.name && parsed?.type_code
         ? [parsed]
         : []
-  return { packName: parsed?.meta?.name ?? null, cards }
+  return {
+    packName: parsed?.meta?.name ?? null,
+    packCode: parsed?.meta?.code ?? null,
+    cards,
+  }
 }
 
 export function arkhamBuildCardToCustomCard(raw: any, packName: string | null): CustomCard {

--- a/frontend/src/arkham/arkhamBuildImport.ts
+++ b/frontend/src/arkham/arkhamBuildImport.ts
@@ -1,0 +1,221 @@
+// Bridges arkham.build's ("Arkham Card Maker") own JSON export format into
+// this app's custom-card model, and rewrites the same card codes wherever
+// they show up in a deck, so a deck built on arkham.build against these same
+// cards resolves against the copies imported here rather than going missing.
+//
+// Deliberately narrow: only the fields a card needs to look right and stat
+// out correctly (name, type, class, cost, stats, traits, art, ...). Ability
+// text/effects are out of scope -- this app has no free-text ability field at
+// all, abilities are authored structurally through the builder's own
+// AbilityEditor/StepsEditor -- so an imported card has no functional effect
+// until someone builds that by hand.
+import { arkhamBuildCustomCardCode, type CustomCard } from '@/arkham/customCards'
+
+const FACTION_TO_CLASS: Record<string, string> = {
+  guardian: 'Guardian',
+  seeker: 'Seeker',
+  rogue: 'Rogue',
+  mystic: 'Mystic',
+  survivor: 'Survivor',
+  neutral: 'Neutral',
+}
+
+const SLOT_NAME_MAP: Record<string, string> = {
+  hand: 'HandSlot',
+  ally: 'AllySlot',
+  body: 'BodySlot',
+  accessory: 'AccessorySlot',
+  arcane: 'ArcaneSlot',
+  tarot: 'TarotSlot',
+  head: 'HeadSlot',
+}
+
+const isWeaknessSubtype = (raw: any) =>
+  raw.subtype_code === 'weakness' || raw.subtype_code === 'basicweakness'
+
+/* Mirrors the reasoning `ALWAYS_WEAKNESS`/`isWeakness` already encode in
+ * CustomCardForm.vue: a treachery or enemy is only ever a *player* card when
+ * it's a weakness -- otherwise it's encounter-side. */
+function mapCardType(raw: any): string {
+  const weak = isWeaknessSubtype(raw)
+  switch (raw.type_code) {
+    case 'investigator':
+      return 'InvestigatorType'
+    case 'asset':
+      return raw.faction_code === 'mythos' ? 'EncounterAssetType' : 'AssetType'
+    case 'event':
+      return 'EventType'
+    case 'skill':
+      return 'SkillType'
+    case 'treachery':
+      return weak ? 'PlayerTreacheryType' : 'TreacheryType'
+    case 'enemy':
+      return weak ? 'PlayerEnemyType' : 'EnemyType'
+    default:
+      return 'AssetType'
+  }
+}
+
+function mapSlots(raw: any): string[] {
+  if (!raw.slot) return []
+  const found = new Set<string>()
+  for (const piece of String(raw.slot).split(/[.,]| and /i)) {
+    const key = SLOT_NAME_MAP[piece.trim().toLowerCase()]
+    if (key) found.add(key)
+  }
+  return [...found]
+}
+
+/* On every card type except an investigator, `skill_*` is an icon *count* --
+ * how many pips are printed -- not a stat. */
+function mapIcons(raw: any): any[] {
+  const icons: any[] = []
+  const push = (n: unknown, tag: string) => {
+    const count = typeof n === 'number' ? n : 0
+    for (let i = 0; i < count; i++) {
+      icons.push(tag === 'Wild' ? { tag: 'WildIcon', contents: [] } : { tag: 'SkillIcon', contents: tag })
+    }
+  }
+  push(raw.skill_willpower, 'SkillWillpower')
+  push(raw.skill_intellect, 'SkillIntellect')
+  push(raw.skill_combat, 'SkillCombat')
+  push(raw.skill_agility, 'SkillAgility')
+  push(raw.skill_wild, 'Wild')
+  return icons
+}
+
+const gameValue = (n: unknown) => (typeof n === 'number' ? { tag: 'Static', contents: n } : null)
+
+const setIf = (obj: Record<string, any>, key: string, value: unknown) => {
+  if (value !== null && value !== undefined) obj[key] = value
+}
+
+/* Accepts a full arkham.build card-pool export ({meta, data:{cards:[...]}}),
+ * a bare {cards:[...]}, or a single card object on its own. */
+export function parseArkhamBuildCards(raw: string): { packName: string | null; cards: any[] } {
+  const parsed = JSON.parse(raw)
+  const cards: any[] = Array.isArray(parsed?.data?.cards)
+    ? parsed.data.cards
+    : Array.isArray(parsed?.cards)
+      ? parsed.cards
+      : parsed?.name && parsed?.type_code
+        ? [parsed]
+        : []
+  return { packName: parsed?.meta?.name ?? null, cards }
+}
+
+export function arkhamBuildCardToCustomCard(raw: any, packName: string | null): CustomCard {
+  const cardCode = arkhamBuildCustomCardCode(raw.code)
+  const cardType = mapCardType(raw)
+  const isWeakness = isWeaknessSubtype(raw)
+  const isEnemy = cardType === 'EnemyType' || cardType === 'PlayerEnemyType'
+  const isAsset = cardType === 'AssetType' || cardType === 'EncounterAssetType'
+  const isTreachery = cardType === 'TreacheryType' || cardType === 'PlayerTreacheryType'
+  const isInvestigator = cardType === 'InvestigatorType'
+  const isPlayerCard = ['AssetType', 'EventType', 'SkillType', 'PlayerTreacheryType', 'PlayerEnemyType'].includes(
+    cardType,
+  )
+  const hasSkillIcons = !isInvestigator && !isEnemy && !isTreachery
+  const hasClass = (isPlayerCard || isInvestigator) && !isWeakness
+  const hasCost = ['AssetType', 'EventType'].includes(cardType) && !isWeakness
+  const hasLevel = isPlayerCard && !isEnemy && !isTreachery && !isWeakness
+
+  const def: Record<string, any> = {
+    cardCode,
+    art: cardCode,
+    cardType,
+    name: {
+      title: (raw.name || '').trim() || 'Custom Card',
+      subtitle: raw.subname?.trim() || null,
+    },
+    cardTraits: String(raw.traits || '')
+      .split('.')
+      .map((t: string) => t.trim())
+      .filter(Boolean),
+    skills: hasSkillIcons ? mapIcons(raw) : [],
+    keywords: [],
+    unique: !!raw.is_unique,
+    permanent: !!raw.permanent,
+    doubleSided: false,
+    meta: { arkhamBuildCode: raw.code } as Record<string, any>,
+  }
+
+  if (hasClass) def.classSymbols = [FACTION_TO_CLASS[raw.faction_code] ?? 'Neutral']
+  if (isWeakness) def.cardSubType = raw.subtype_code === 'basicweakness' ? 'BasicWeakness' : 'Weakness'
+
+  if (hasCost) setIf(def, 'cost', typeof raw.cost === 'number' ? { tag: 'StaticCost', contents: raw.cost } : null)
+  if (hasLevel) setIf(def, 'level', typeof raw.xp === 'number' ? raw.xp : null)
+
+  if (isEnemy) {
+    setIf(def, 'fight', gameValue(raw.enemy_fight))
+    setIf(def, 'health', gameValue(raw.health))
+    setIf(def, 'evade', gameValue(raw.enemy_evade))
+    setIf(def, 'healthDamage', gameValue(raw.enemy_damage))
+    setIf(def, 'sanityDamage', gameValue(raw.enemy_horror))
+  }
+
+  if (isAsset) {
+    const slots = mapSlots(raw)
+    if (slots.length) def.slots = slots
+    setIf(def.meta, 'health', typeof raw.health === 'number' ? raw.health : null)
+    setIf(def.meta, 'sanity', typeof raw.sanity === 'number' ? raw.sanity : null)
+  }
+
+  if (raw.position != null) def.meta.number = String(raw.position)
+  if (packName) def.meta.set = packName
+
+  if (isInvestigator) {
+    def.meta.health = typeof raw.health === 'number' ? raw.health : 0
+    def.meta.sanity = typeof raw.sanity === 'number' ? raw.sanity : 0
+    def.meta.willpower = typeof raw.skill_willpower === 'number' ? raw.skill_willpower : 0
+    def.meta.intellect = typeof raw.skill_intellect === 'number' ? raw.skill_intellect : 0
+    def.meta.combat = typeof raw.skill_combat === 'number' ? raw.skill_combat : 0
+    def.meta.agility = typeof raw.skill_agility === 'number' ? raw.skill_agility : 0
+    if (raw.back_image_url) def.meta.backArt = raw.back_image_url
+  }
+
+  return { def: def as any, art: raw.image_url || null }
+}
+
+// ---------------------------------------------------------- deck codes ---
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+const translateCode = (code: string): string => (UUID_RE.test(code) ? arkhamBuildCustomCardCode(code) : code)
+
+const translateSlots = (slots?: Record<string, number>): Record<string, number> | undefined =>
+  slots
+    ? Object.fromEntries(Object.entries(slots).map(([code, qty]) => [translateCode(code), qty]))
+    : slots
+
+/* A deck exported from arkham.build names cards by the same bare UUIDs its
+ * card-pool export uses. Nothing in this app's deck-lookup or backend
+ * validation ever tries a custom-card match unless the code already starts
+ * with `*` (isCustomCardCode), so a deck built against arkham.build custom
+ * cards needs those UUIDs rewritten to this app's derived codes before it's
+ * validated or created -- otherwise it is silently dropped from view (or
+ * rejected outright as UnimplementedCard) even after the matching cards have
+ * been imported. A decklist built entirely from official cards is untouched:
+ * ArkhamDB codes never match UUID_RE. */
+export function normalizeArkhamBuildDeckCodes<T extends Record<string, any>>(deck: T): T {
+  const out: any = { ...deck }
+  if (out.slots) out.slots = translateSlots(out.slots)
+  if (out.sideSlots) out.sideSlots = translateSlots(out.sideSlots)
+  if (typeof out.investigator_code === 'string') out.investigator_code = translateCode(out.investigator_code)
+
+  const meta = typeof out.meta === 'string'
+    ? (() => {
+        try {
+          return JSON.parse(out.meta)
+        } catch {
+          return null
+        }
+      })()
+    : out.meta
+  if (meta && typeof meta.alternate_front === 'string') {
+    const patched = { ...meta, alternate_front: translateCode(meta.alternate_front) }
+    out.meta = typeof out.meta === 'string' ? JSON.stringify(patched) : patched
+  }
+
+  return out
+}

--- a/frontend/src/arkham/arkhamBuildImport.ts
+++ b/frontend/src/arkham/arkhamBuildImport.ts
@@ -191,7 +191,16 @@ export function arkhamBuildCardToCustomCard(raw: any, packName: string | null): 
 
 // ---------------------------------------------------------- deck codes ---
 
-const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+/* arkham.build identifies a custom card by a bare id, and not always a dashed
+ * UUID: a pack's cards come through with a short hex id instead. The importer
+ * derives a code from whatever it is handed (`arkhamBuildCustomCardCode` does
+ * not check the shape), so the deck side has to accept the same set -- gating
+ * on the dashed form alone left short-id cards untranslated, and a deck naming
+ * them failed validation as UnimplementedCard even though those cards had been
+ * imported and were sitting in the library. ArkhamDB codes are five or six
+ * digits and match none of these. */
+const UUID_RE =
+  /^(?:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}|[0-9a-f]{32}|[0-9a-f]{8})$/i
 
 const translateCode = (code: string): string => (UUID_RE.test(code) ? arkhamBuildCustomCardCode(code) : code)
 

--- a/frontend/src/arkham/components/NewDeck.vue
+++ b/frontend/src/arkham/components/NewDeck.vue
@@ -8,6 +8,8 @@ import ArkhamDbDeck from '@/arkham/components/ArkhamDbDeck.vue';
 import { ArkhamDbDecklist } from '@/arkham/types/Deck';
 import { useCardStore } from '@/stores/cards'
 import { normalizeArkhamBuildDeckCodes } from '@/arkham/arkhamBuildImport'
+import { libraryCard, loadLibrary } from '@/arkham/customCardLibrary'
+import { arkhamBuildCustomCardCode } from '@/arkham/customCards'
 
 const { t } = useI18n()
 
@@ -54,6 +56,13 @@ function validationErrorsFromResponse(err: unknown): string[] {
     const key = normalizeCode(code)
     const hit = cardByCode.value.get(key)
     if (hit) return hit.xp ? `${hit.name.title} (${hit.xp})` : hit.name.title
+    /* Not an official card, so try the custom library before giving up on the
+     * name. The code arrives either as this app's own derived code or as the
+     * arkham.build id the deck was built against, which derives to it. A def
+     * stores its code with the leading `c` that `normalizeCode` strips. */
+    const custom =
+      libraryCard(`c${key}`) ?? libraryCard(`c${arkhamBuildCustomCardCode(key)}`)
+    if (custom) return `${custom.def.name.title} (custom)`
     return `Unknown card: ${code}`
   })
 }
@@ -181,6 +190,9 @@ async function runValidations() {
     await validateDeck(deckList.value)
     valid.value = true
   } catch (err: unknown) {
+    // The custom library is what names a custom card in the error list, and
+    // this page never needed it before now.
+    await loadLibrary()
     errors.value = validationErrorsFromResponse(err)
   }
 }
@@ -212,6 +224,7 @@ async function createDeck() {
     deck.value = null
     emit('newDeck', created)
   } catch (err: unknown) {
+    await loadLibrary()
     errors.value = validationErrorsFromResponse(err)
   }
 }

--- a/frontend/src/arkham/components/NewDeck.vue
+++ b/frontend/src/arkham/components/NewDeck.vue
@@ -7,6 +7,7 @@ import { fetchInvestigators, newDeck, validateDeck } from '@/arkham/api'
 import ArkhamDbDeck from '@/arkham/components/ArkhamDbDeck.vue';
 import { ArkhamDbDecklist } from '@/arkham/types/Deck';
 import { useCardStore } from '@/stores/cards'
+import { normalizeArkhamBuildDeckCodes } from '@/arkham/arkhamBuildImport'
 
 const { t } = useI18n()
 
@@ -102,7 +103,11 @@ function loadDeckFromFile(e: Event) {
     const reader = new FileReader()
     reader.onloadend = (e1: ProgressEvent<FileReader>) => {
       if(!e1?.target?.result) return
-      let data = JSON.parse(e1.target.result.toString())
+      // A file downloaded straight from arkham.build has the same shape its
+      // share API returns, including bare-UUID custom card codes, which need
+      // the same rewrite `processArkhamBuildDeck` applies to a fetched deck --
+      // this path bypasses that function entirely, so it has to be done here.
+      let data = normalizeArkhamBuildDeckCodes(JSON.parse(e1.target.result.toString()))
       deckList.value = data
       investigator.value = null
       investigatorError.value = null

--- a/frontend/src/arkham/components/debug/CustomCardForm.vue
+++ b/frontend/src/arkham/components/debug/CustomCardForm.vue
@@ -127,7 +127,6 @@ const blankForm = () => ({
   actions: [] as string[],
   // grouping, so a set of cards made together can be found together
   cardNumber: '',
-  setName: '',
   // investigator
   elderSign: '1',
   elderSignRevealSteps: [] as any[],
@@ -469,7 +468,6 @@ function buildDef(cardCode: string): Record<string, any> {
   }
 
   if (form.cardNumber.trim()) def.meta.number = form.cardNumber.trim()
-  if (form.setName.trim()) def.meta.set = form.setName.trim()
 
   if (isInvestigator.value) {
     if (num(form.elderSign) !== null) def.meta._elderSign = num(form.elderSign)
@@ -681,7 +679,6 @@ async function loadCard(card: CustomCard) {
   form.investigatorSanity = meta.sanity === undefined ? '7' : String(meta.sanity)
   form.signatures = (meta._signatures ?? []).map(stripCardCodePrefix)
   form.cardNumber = meta.number ?? ''
-  form.setName = meta.set ?? ''
   form.elderSign = meta._elderSign === undefined ? '1' : String(meta._elderSign)
   form.elderSignRevealSteps = meta._elderSignRevealSteps ?? []
   form.elderSignSteps = meta._elderSignSteps ?? []
@@ -864,10 +861,6 @@ defineExpose({ loadCard, reset, buildCustomCard, cardType: computed(() => form.c
             <label>
               Card number
               <input v-model="form.cardNumber" type="text" placeholder="1" @keydown.stop />
-            </label>
-            <label>
-              Set
-              <input v-model="form.setName" type="text" placeholder="My Expansion" @keydown.stop />
             </label>
           </div>
 

--- a/frontend/src/arkham/customCardLibrary.ts
+++ b/frontend/src/arkham/customCardLibrary.ts
@@ -11,19 +11,23 @@ import {
   cardArtReference,
   normalizeCardDef,
   registerCustomCards,
+  unregisterCustomCard,
   type CustomCard,
 } from '@/arkham/customCards'
 
-export type LibraryCard = CustomCard & { id: string; updatedAt: string }
+export type LibraryCard = CustomCard & { id: string; setId: string; updatedAt: string }
+export type LibrarySet = Api.StoredCustomCardSet
 
 const LEGACY_STORAGE_KEY = 'arkham:custom-card-library'
 
 const entries = reactive<LibraryCard[]>([])
+const sets = reactive<LibrarySet[]>([])
 export const libraryLoaded = ref(false)
 let loading: Promise<void> | null = null
 
 const toLibraryCard = (row: Api.StoredCustomCard): LibraryCard => ({
   id: row.id,
+  setId: row.setId,
   def: normalizeCardDef(row.def),
   art: row.art,
   updatedAt: row.updatedAt,
@@ -36,9 +40,25 @@ function replaceAll(rows: Api.StoredCustomCard[]) {
   registerCustomCards(entries)
 }
 
+/* A set's card count is maintained here rather than re-fetched: the server
+ * sends it with the set, but every local add and removal has to keep it true
+ * until the next load or the sidebar counts drift. */
+function recountSets() {
+  for (const set of sets) {
+    set.cardCount = entries.filter((e) => e.setId === set.id).length
+  }
+}
+
+function upsertSet(set: LibrarySet) {
+  const index = sets.findIndex((s) => s.id === set.id)
+  if (index === -1) sets.push(set)
+  else sets.splice(index, 1, set)
+}
+
 /* Cards made before the library moved server-side live in this browser only.
  * Push them up once, then drop the local copy so there is a single source of
- * truth. */
+ * truth. They predate sets, so they arrive as one, named after whatever set
+ * name they were carrying. */
 async function migrateLegacyCards() {
   let legacy: { def: any; art: string | null }[] = []
   try {
@@ -56,18 +76,50 @@ async function migrateLegacyCards() {
   }
 
   try {
-    await Api.importCustomCards(legacy.map((c) => ({ def: c.def, art: c.art ?? null })))
+    for (const [name, cards] of groupByDeclaredSet(legacy)) {
+      await Api.importCustomCardSet({
+        name,
+        sourceCode: null,
+        cards: cards.map((c) => ({ def: c.def, art: c.art ?? null })),
+      })
+    }
     localStorage.removeItem(LEGACY_STORAGE_KEY)
   } catch (error) {
     console.error(error)
   }
 }
 
+/* The set name a loose card carries in its own def -- what grouping used to be
+ * before a set was a real thing. Read when cards arrive from outside (a legacy
+ * browser library, an export file) and have to be put into one. */
+function declaredSetName(card: { def: any }): string | null {
+  const name = card.def?.meta?.set
+  return typeof name === 'string' && name.trim() ? name.trim() : null
+}
+
+const UNNAMED_SET = 'Imported cards'
+
+function groupByDeclaredSet(cards: { def: any; art: string | null }[]) {
+  const groups = new Map<string, { def: any; art: string | null }[]>()
+  for (const card of cards) {
+    const name = declaredSetName(card) ?? UNNAMED_SET
+    if (!groups.has(name)) groups.set(name, [])
+    groups.get(name)!.push(card)
+  }
+  return groups
+}
+
 export async function loadLibrary(force = false) {
   if (libraryLoaded.value && !force) return
   loading ??= (async () => {
     await migrateLegacyCards()
-    replaceAll(await Api.fetchCustomCardLibrary())
+    const [setRows, cardRows] = await Promise.all([
+      Api.fetchCustomCardSets(),
+      Api.fetchCustomCardLibrary(),
+    ])
+    sets.splice(0, sets.length, ...setRows)
+    replaceAll(cardRows)
+    recountSets()
     libraryLoaded.value = true
   })()
 
@@ -92,12 +144,89 @@ export function libraryCard(cardCode: string): LibraryCard | undefined {
   return entries.find((e) => e.def.cardCode === cardCode)
 }
 
-export async function saveToLibrary(card: CustomCard): Promise<LibraryCard> {
-  const saved = toLibraryCard(await Api.saveCustomCard({ def: card.def, art: card.art }))
+// ------------------------------------------------------------------ sets ---
+
+export function librarySets(): LibrarySet[] {
+  return [...sets].sort((a, b) => a.name.localeCompare(b.name))
+}
+
+export const librarySet = (id: string | null): LibrarySet | undefined =>
+  id ? sets.find((s) => s.id === id) : undefined
+
+export const setCards = (setId: string): LibraryCard[] =>
+  libraryCards().filter((c) => c.setId === setId)
+
+export async function createSet(name: string): Promise<LibrarySet> {
+  const set = await Api.createCustomCardSet(name)
+  upsertSet(set)
+  return set
+}
+
+export async function renameSet(id: string, name: string): Promise<LibrarySet> {
+  const set = await Api.renameCustomCardSet(id, name)
+  upsertSet(set)
+  /* The name is stamped onto every card in the set so a card exported on its
+   * own still says where it came from; the server rewrites them, and the copies
+   * held here have to follow or the library would show the old name until a
+   * reload. */
+  for (const card of entries) {
+    if (card.setId === id) card.def.meta = { ...card.def.meta, set: set.name }
+  }
+  registerCustomCards(entries.filter((c) => c.setId === id))
+  return set
+}
+
+/* Deleting a set deletes what is in it -- the point of the set being the unit
+ * you can change your mind about, rather than 150 cards you delete one by one. */
+export async function removeSet(id: string) {
+  await Api.deleteCustomCardSet(id)
+  for (let i = entries.length - 1; i >= 0; i--) {
+    if (entries[i].setId === id) {
+      unregisterCustomCard(entries[i].def.cardCode)
+      entries.splice(i, 1)
+    }
+  }
+  const index = sets.findIndex((s) => s.id === id)
+  if (index !== -1) sets.splice(index, 1)
+}
+
+/* Replaces the set's contents wholesale rather than merging into them: an
+ * import is the whole set as it now stands, so a card the new file dropped has
+ * to be gone here too. */
+export async function importSet(payload: {
+  name: string
+  sourceCode: string | null
+  cards: CustomCard[]
+}): Promise<LibrarySet> {
+  const { set, cards } = await Api.importCustomCardSet({
+    name: payload.name,
+    sourceCode: payload.sourceCode,
+    cards: payload.cards.map((c) => ({ def: c.def, art: c.art })),
+  })
+
+  for (let i = entries.length - 1; i >= 0; i--) {
+    if (entries[i].setId === set.id) {
+      unregisterCustomCard(entries[i].def.cardCode)
+      entries.splice(i, 1)
+    }
+  }
+  const imported = cards.map(toLibraryCard)
+  entries.push(...imported)
+  registerCustomCards(imported)
+  upsertSet(set)
+  recountSets()
+  return set
+}
+
+// ----------------------------------------------------------------- cards ---
+
+export async function saveToLibrary(card: CustomCard, setId: string): Promise<LibraryCard> {
+  const saved = toLibraryCard(await Api.saveCustomCard({ setId, def: card.def, art: card.art }))
   const index = entries.findIndex((e) => e.def.cardCode === saved.def.cardCode)
   if (index === -1) entries.push(saved)
   else entries.splice(index, 1, saved)
   registerCustomCards([saved])
+  recountSets()
   return saved
 }
 
@@ -107,26 +236,24 @@ export async function removeFromLibrary(cardCode: string) {
   const [removed] = entries.splice(index, 1)
   try {
     await Api.deleteCustomCard(removed.id)
+    recountSets()
   } catch (error) {
     console.error(error)
     entries.splice(index, 0, removed)
   }
 }
 
-export async function importLibraryCards(cards: CustomCard[]): Promise<LibraryCard[]> {
-  const saved = (await Api.importCustomCards(cards.map((c) => ({ def: c.def, art: c.art })))).map(toLibraryCard)
-  for (const card of saved) {
-    const index = entries.findIndex((e) => e.def.cardCode === card.def.cardCode)
-    if (index === -1) entries.push(card)
-    else entries.splice(index, 1, card)
-  }
-  registerCustomCards(saved)
-  return saved
+/* 2 carries the set the cards came from; 1 was cards alone. Both import -- a
+ * version 1 file falls back to the set name each card names for itself. */
+export const EXPORT_VERSION = 2
+
+export type CardExport = {
+  version: number
+  set?: { name: string; sourceCode: string | null }
+  cards: { def: any; art: string | null }[]
 }
 
-export const EXPORT_VERSION = 1
-
-export type CardExport = { version: number; cards: { def: any; art: string | null }[] }
+export type ParsedCardExport = { name: string; sourceCode: string | null; cards: CustomCard[] }
 
 /* An export carries the image itself, not a link to it.
  *
@@ -137,14 +264,18 @@ export type CardExport = { version: number; cards: { def: any; art: string | nul
  *
  * Falls back to the URL when the image cannot be read: a production asset host
  * that sends no CORS headers refuses the fetch, and half an export beats none. */
-export async function exportCards(cards: CustomCard[]): Promise<CardExport> {
+export async function exportCards(cards: CustomCard[], set?: LibrarySet): Promise<CardExport> {
   const inlined = await Promise.all(
     cards.map(async (c) => ({
       def: await inlineDefArt(c.def),
       art: (await inlineArt(c.art)) ?? c.art,
     })),
   )
-  return { version: EXPORT_VERSION, cards: inlined }
+  return {
+    version: EXPORT_VERSION,
+    ...(set ? { set: { name: set.name, sourceCode: set.sourceCode } } : {}),
+    cards: inlined,
+  }
 }
 
 /* An investigator has more images than its face — a card back and two portraits
@@ -184,11 +315,20 @@ async function inlineArt(art: string | null): Promise<string | null> {
 }
 
 /* Accepts a whole export file or a single card, so a card pasted on its own
- * imports as readily as a file of many. */
-export function parseCardExport(raw: string): CustomCard[] {
+ * imports as readily as a file of many. Everything lands in a set: the one the
+ * file names, else the one the cards name for themselves, else `fallbackName`
+ * (the file's own name, which is all that is left to go on). */
+export function parseCardExport(raw: string, fallbackName = 'Imported cards'): ParsedCardExport {
   const parsed = JSON.parse(raw)
-  const cards = Array.isArray(parsed) ? parsed : (parsed.cards ?? [parsed])
-  return cards
+  const rows = Array.isArray(parsed) ? parsed : (parsed.cards ?? [parsed])
+  const cards: CustomCard[] = rows
     .filter((c: any) => c?.def?.cardCode)
     .map((c: any) => ({ def: c.def, art: c.art ?? null }))
+
+  const declared = typeof parsed?.set?.name === 'string' ? parsed.set.name.trim() : ''
+  return {
+    name: declared || (cards.length ? declaredSetName(cards[0]) : null) || fallbackName,
+    sourceCode: parsed?.set?.sourceCode ?? null,
+    cards,
+  }
 }

--- a/frontend/src/arkham/customCards.ts
+++ b/frontend/src/arkham/customCards.ts
@@ -53,6 +53,14 @@ export function mintCustomCardCode(): string {
   return `${CUSTOM_CARD_PREFIX}${crypto.randomUUID().replace(/-/g, '')}0`
 }
 
+/* Same shape as `mintCustomCardCode`, but derived from an arkham.build card's
+ * own UUID rather than a fresh random one. Importing a card and later reading
+ * a deck that names it by that UUID need to land on the same code, so this has
+ * to be deterministic -- a random mint would never match up with itself. */
+export function arkhamBuildCustomCardCode(uuid: string): string {
+  return `${CUSTOM_CARD_PREFIX}${uuid.replace(/-/g, '').toLowerCase()}0`
+}
+
 /* A def written by the builder only carries the fields that card needed, and a
  * def that came off the wire went through `cardDefDecoder`, which fills in the
  * rest. Anything that reads a custom def as a `CardDef` -- the deck page, the

--- a/frontend/src/arkham/helpers.ts
+++ b/frontend/src/arkham/helpers.ts
@@ -11,6 +11,7 @@ import {
   customCardPlaceholder,
   isCustomCardCode,
 } from '@/arkham/customCards'
+import { normalizeArkhamBuildDeckCodes } from '@/arkham/arkhamBuildImport'
 
 interface ImageHelper {
   root: string
@@ -310,7 +311,11 @@ export function processArkhamBuildDeck<T extends { slots?: Record<string, number
     [key: string]: unknown
   }
   const mergedSlots = { ...(data.slots ?? {}), ...(hiddenSlotCards ?? {}) }
-  return { ...data, ...hiddenRest, slots: mergedSlots, url }
+  // arkham.build names a custom card by its own bare UUID; this app only ever
+  // recognizes a custom card by a `*`-prefixed code, so any such code here has
+  // to be rewritten before this deck reaches validation or it will look like
+  // it references cards that don't exist.
+  return normalizeArkhamBuildDeckCodes({ ...data, ...hiddenRest, slots: mergedSlots, url })
 }
 
 export function isTypingTarget(target: EventTarget | null): boolean {

--- a/frontend/src/arkham/views/CardBuilder.vue
+++ b/frontend/src/arkham/views/CardBuilder.vue
@@ -4,24 +4,31 @@
  *
  * In a game you only pick from this library; building and editing happen here,
  * where there is room for it. */
-import { computed, onMounted, ref, watch } from 'vue'
+import { computed, nextTick, onMounted, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import CustomCardForm from '@/arkham/components/debug/CustomCardForm.vue'
 import { stripCardCodePrefix } from '@/arkham/customCards'
 import {
   mintCustomCardCode,
-  registerCustomCards,
   renderCardPlaceholder,
   type CustomCard,
 } from '@/arkham/customCards'
 import {
+  createSet,
   exportCards,
-  importLibraryCards,
+  importSet,
+  libraryCard,
   libraryCards,
   libraryLoaded,
+  librarySet,
+  librarySets,
   loadLibrary,
   removeFromLibrary,
+  removeSet,
+  renameSet,
   saveToLibrary,
+  setCards,
+  type LibrarySet,
 } from '@/arkham/customCardLibrary'
 
 const form = ref<InstanceType<typeof CustomCardForm> | null>(null)
@@ -32,6 +39,14 @@ const libraryCollapsed = ref(false)
 const status = ref<string | null>(null)
 const error = ref<string | null>(null)
 
+/* Which set new cards are written into. Remembered across visits because it is
+ * the thing you are working on, not a filter you re-pick every time. */
+const ACTIVE_SET_KEY = 'arkham:card-builder:active-set'
+const activeSetId = ref<string | null>(null)
+const newSetName = ref('')
+const renamingSetId = ref<string | null>(null)
+const renameDraft = ref('')
+
 const route = useRoute()
 const router = useRouter()
 
@@ -41,6 +56,7 @@ const router = useRouter()
  * a link followed while already here still lands. */
 async function openFromRoute() {
   await loadLibrary()
+  ensureActiveSet()
   const wanted = route.query.card
   if (typeof wanted !== 'string') return
   // A code travels with the 'c' the engine prepends or without it, and the
@@ -55,21 +71,44 @@ onMounted(openFromRoute)
 watch(() => route.query.card, openFromRoute)
 
 const cards = computed(() => libraryCards())
+const sets = computed(() => librarySets())
+const activeSet = computed(() => librarySet(activeSetId.value))
 
-/* Cards are grouped by the set they name, so a batch built together stays
- * together the way the card browser groups an expansion. */
-const grouped = computed(() => {
-  const groups = new Map<string, typeof cards.value>()
-  for (const card of cards.value) {
-    const set = card.def.meta?.set?.trim() || 'Ungrouped'
-    if (!groups.has(set)) groups.set(set, [])
-    groups.get(set)!.push(card)
-  }
-  for (const list of groups.values()) {
-    list.sort((a, b) => (a.def.meta?.number ?? '').localeCompare(b.def.meta?.number ?? '', undefined, { numeric: true }))
-  }
-  return [...groups.entries()].sort(([a], [b]) => (a === 'Ungrouped' ? 1 : b === 'Ungrouped' ? -1 : a.localeCompare(b)))
+/* The set being worked on, and the cards in it, in printed order. A card is
+ * built into a set, so the builder shows one at a time rather than the whole
+ * library at once. */
+const activeCards = computed(() => {
+  if (!activeSetId.value) return []
+  return setCards(activeSetId.value).sort((a, b) =>
+    (a.def.meta?.number ?? '').localeCompare(b.def.meta?.number ?? '', undefined, { numeric: true }),
+  )
 })
+
+/* Falls back to whatever set is first rather than leaving nothing selected: a
+ * builder with sets in it should always be pointed at one of them. */
+function chooseActiveSet(id: string | null) {
+  activeSetId.value = id
+  selected.value = []
+  try {
+    if (id) localStorage.setItem(ACTIVE_SET_KEY, id)
+    else localStorage.removeItem(ACTIVE_SET_KEY)
+  } catch {
+    // A browser refusing storage is not a reason to fail to switch sets.
+  }
+}
+
+function ensureActiveSet() {
+  if (activeSetId.value && sets.value.some((s) => s.id === activeSetId.value)) return
+  let remembered: string | null = null
+  try {
+    remembered = localStorage.getItem(ACTIVE_SET_KEY)
+  } catch {
+    remembered = null
+  }
+  const known = remembered && sets.value.some((s) => s.id === remembered) ? remembered : null
+  chooseActiveSet(known ?? sets.value[0]?.id ?? null)
+}
+
 const cardArt = (card: CustomCard) => card.art ?? renderCardPlaceholder(card.def)
 const isSelected = (code: string) => selected.value.includes(code)
 
@@ -79,20 +118,60 @@ function toggleSelected(code: string) {
   else selected.value.splice(index, 1)
 }
 
-const selectAll = () => (selected.value = cards.value.map((c) => c.def.cardCode))
+const selectAll = () => (selected.value = activeCards.value.map((c) => c.def.cardCode))
 const clearSelection = () => (selected.value = [])
 
-/* A set is how a batch built together is kept together, so it is also the unit
- * you hand to someone else — and the unit you select. */
-const setFullySelected = (setCards: CustomCard[]) =>
-  setCards.length > 0 && setCards.every((c) => isSelected(c.def.cardCode))
+// -------------------------------------------------------------------- sets ---
 
-function toggleSet(setCards: CustomCard[]) {
-  const codes = setCards.map((c) => c.def.cardCode)
-  if (setFullySelected(setCards)) {
-    selected.value = selected.value.filter((code) => !codes.includes(code))
-  } else {
-    selected.value = [...new Set([...selected.value, ...codes])]
+async function addSet() {
+  const name = newSetName.value.trim()
+  if (!name) return
+  error.value = null
+  try {
+    const set = await createSet(name)
+    newSetName.value = ''
+    chooseActiveSet(set.id)
+    startNew()
+  } catch (e) {
+    console.error(e)
+    error.value = 'Could not create that set.'
+  }
+}
+
+function startRename(set: LibrarySet) {
+  renamingSetId.value = set.id
+  renameDraft.value = set.name
+}
+
+async function commitRename(set: LibrarySet) {
+  const name = renameDraft.value.trim()
+  renamingSetId.value = null
+  if (!name || name === set.name) return
+  error.value = null
+  try {
+    await renameSet(set.id, name)
+  } catch (e) {
+    console.error(e)
+    error.value = 'Could not rename that set.'
+  }
+}
+
+/* The whole point of a set: changing your mind about an import you just made is
+ * one decision, so the count is spelled out rather than left to be discovered. */
+async function dropSet(set: LibrarySet) {
+  const count = set.cardCount
+  const what = count === 1 ? 'its 1 card' : `its ${count} cards`
+  if (!confirm(`Delete "${set.name}" and ${count ? what : 'nothing else — it is empty'}?`)) return
+  error.value = null
+  try {
+    const editing = editingCode.value
+    await removeSet(set.id)
+    if (activeSetId.value === set.id) chooseActiveSet(sets.value[0]?.id ?? null)
+    if (editing && !libraryCard(editing)) startNew()
+    status.value = `Deleted "${set.name}".`
+  } catch (e) {
+    console.error(e)
+    error.value = 'Could not delete that set.'
   }
 }
 
@@ -100,6 +179,12 @@ async function edit(card: CustomCard) {
   editingCode.value = card.def.cardCode
   status.value = null
   error.value = null
+  /* Opening a card from elsewhere -- a game, or an investigator's signature --
+   * switches to the set it lives in, so the library beside it is showing the
+   * card that is open. */
+  const owned = libraryCard(card.def.cardCode)
+  if (owned && owned.setId !== activeSetId.value) chooseActiveSet(owned.setId)
+  await nextTick()
   await form.value?.loadCard(card)
   syncRoute(card.def.cardCode)
 }
@@ -129,6 +214,15 @@ function syncRoute(cardCode: string | null) {
 }
 
 async function save() {
+  /* A card is written into a set, so there has to be one. Editing a card keeps
+   * it in the set it is already in rather than moving it to whichever set
+   * happens to be active. */
+  const setId = (editingCode.value ? libraryCard(editingCode.value)?.setId : null) ?? activeSetId.value
+  if (!setId) {
+    error.value = 'Make a set first — a card has to go in one.'
+    return
+  }
+
   busy.value = true
   error.value = null
   status.value = null
@@ -138,9 +232,8 @@ async function save() {
     // than leaving a second copy behind.
     const card = form.value?.buildCustomCard(editingCode.value ?? mintCustomCardCode())
     if (!card) return
-    await saveToLibrary(card)
-    registerCustomCards([card])
-    editingCode.value = card.def.cardCode
+    const saved = await saveToLibrary(card, setId)
+    editingCode.value = saved.def.cardCode
     status.value = 'Saved.'
   } catch (e) {
     console.error(e)
@@ -159,9 +252,9 @@ async function remove(card: CustomCard) {
 
 // ---------------------------------------------------------------- export ---
 
-async function download(cards: CustomCard[], filename: string) {
+async function download(cards: CustomCard[], filename: string, set?: LibrarySet) {
   // The art is fetched and inlined, so this waits on the network.
-  const blob = new Blob([JSON.stringify(await exportCards(cards), null, 2)], {
+  const blob = new Blob([JSON.stringify(await exportCards(cards, set), null, 2)], {
     type: 'application/json',
   })
   const url = URL.createObjectURL(blob)
@@ -176,11 +269,14 @@ const slug = (text: string) => text.toLowerCase().replace(/[^a-z0-9]+/g, '-').re
 
 const exportOne = (card: CustomCard) => download([card], `${slug(card.def.name.title)}.arkhamcard.json`)
 
-const exportSet = (set: string, setCards: CustomCard[]) =>
-  download(setCards, `${slug(set)}.arkhamcard.json`)
+/* A set exports as a set, naming itself in the file, so importing it again --
+ * here or on someone else's account -- lands as that set rather than as loose
+ * cards needing somewhere to go. */
+const exportSet = (set: LibrarySet) =>
+  download(setCards(set.id), `${slug(set.name)}.arkhamcard.json`, set)
 
 async function exportSelected() {
-  const chosen = cards.value.filter((c) => isSelected(c.def.cardCode))
+  const chosen = activeCards.value.filter((c) => isSelected(c.def.cardCode))
   if (!chosen.length) return
   await download(
     chosen,
@@ -188,28 +284,53 @@ async function exportSelected() {
   )
 }
 
+/* Everything imported arrives as a set, replacing one of the same name rather
+ * than merging into it. A file that names no set falls back to what the cards
+ * claim, and failing that to the file's own name. */
+async function importFile(file: File, parse: (text: string) => Promise<{
+  name: string
+  sourceCode: string | null
+  cards: CustomCard[]
+}>) {
+  error.value = null
+  status.value = null
+  try {
+    const { name, sourceCode, cards: incoming } = await parse(await file.text())
+    if (!incoming.length) {
+      error.value = 'That file has no cards in it.'
+      return
+    }
+
+    const replacing = sets.value.find(
+      (s) => (sourceCode && s.sourceCode === sourceCode) || s.name === name,
+    )
+    const prompt = replacing
+      ? `Replace "${replacing.name}" (${replacing.cardCount} cards) with the ${incoming.length} in this file?`
+      : `Import ${incoming.length} card${incoming.length === 1 ? '' : 's'} as "${name}"?`
+    if (!confirm(prompt)) return
+
+    const editing = editingCode.value
+    const set = await importSet({ name, sourceCode, cards: incoming })
+    chooseActiveSet(set.id)
+    if (editing && !libraryCard(editing)) startNew()
+    status.value = `Imported ${incoming.length} card${incoming.length === 1 ? '' : 's'} into "${set.name}".`
+  } catch (e) {
+    console.error(e)
+    error.value = 'Could not read that file.'
+  }
+}
+
+const fileBaseName = (file: File) => file.name.replace(/\.[^.]+$/, '').replace(/\.arkhamcard$/, '')
+
 async function onImport(event: Event) {
   const input = event.target as HTMLInputElement
   const file = input.files?.[0]
   input.value = ''
   if (!file) return
-
-  error.value = null
-  status.value = null
-  try {
+  await importFile(file, async (text) => {
     const { parseCardExport } = await import('@/arkham/customCardLibrary')
-    const imported = parseCardExport(await file.text())
-    if (!imported.length) {
-      error.value = 'That file has no cards in it.'
-      return
-    }
-    const saved = await importLibraryCards(imported)
-    registerCustomCards(saved)
-    status.value = `Imported ${saved.length} card${saved.length === 1 ? '' : 's'}.`
-  } catch (e) {
-    console.error(e)
-    error.value = 'Could not read that file.'
-  }
+    return parseCardExport(text, fileBaseName(file))
+  })
 }
 
 /* A different source format from `onImport` above: an arkham.build ("Arkham
@@ -224,26 +345,15 @@ async function onImportArkhamBuild(event: Event) {
   const file = input.files?.[0]
   input.value = ''
   if (!file) return
-
-  error.value = null
-  status.value = null
-  try {
+  await importFile(file, async (text) => {
     const { parseArkhamBuildCards, arkhamBuildCardToCustomCard } = await import('@/arkham/arkhamBuildImport')
-    const { packName, cards: rawCards } = parseArkhamBuildCards(await file.text())
-    if (!rawCards.length) {
-      error.value = 'That file has no cards in it.'
-      return
+    const { packName, packCode, cards: rawCards } = parseArkhamBuildCards(text)
+    return {
+      name: packName ?? fileBaseName(file),
+      sourceCode: packCode,
+      cards: rawCards.map((raw: any) => arkhamBuildCardToCustomCard(raw, packName)),
     }
-    if (!confirm(`Import ${rawCards.length} card${rawCards.length === 1 ? '' : 's'} from this file?`)) return
-
-    const built = rawCards.map((raw: any) => arkhamBuildCardToCustomCard(raw, packName))
-    const saved = await importLibraryCards(built)
-    registerCustomCards(saved)
-    status.value = `Imported ${saved.length} card${saved.length === 1 ? '' : 's'}.`
-  } catch (e) {
-    console.error(e)
-    error.value = 'Could not read that file as an arkham.build export.'
-  }
+  })
 }
 </script>
 
@@ -261,8 +371,10 @@ async function onImportArkhamBuild(event: Event) {
         >
           «
         </button>
-        <h2>Library</h2>
-        <button type="button" class="new-card" @click="startNew">+ New</button>
+        <h2>Sets</h2>
+        <button type="button" class="new-card" :disabled="!activeSetId" @click="startNew">
+          + New card
+        </button>
       </div>
 
       <div class="library-tools">
@@ -270,48 +382,82 @@ async function onImportArkhamBuild(event: Event) {
           <span>Import</span>
           <input type="file" accept="application/json,.json" @change="onImport" />
         </label>
-        <button type="button" class="tool" :disabled="!selected.length" @click="exportSelected">
-          Export{{ selected.length ? ` (${selected.length})` : '' }}
-        </button>
-        <button type="button" class="tool" :disabled="!cards.length" @click="selectAll">
-          Select all
-        </button>
-        <button type="button" class="tool" :disabled="!selected.length" @click="clearSelection">
-          Clear
-        </button>
-        <label class="tool import wide">
+        <label class="tool import">
           <span>Import arkham.build</span>
           <input type="file" accept="application/json,.json" @change="onImportArkhamBuild" />
         </label>
       </div>
 
       <p v-if="!libraryLoaded" class="muted">Loading…</p>
-      <p v-else-if="!cards.length" class="muted">
-        No cards yet. Build one and it will be waiting here next time.
-      </p>
 
       <template v-else>
-        <div v-for="[set, setCards] in grouped" :key="set" class="library-group">
-          <div class="group-head">
-            <h3>{{ set }}</h3>
-            <span class="group-count">{{ setCards.length }}</span>
+        <ul class="set-list">
+          <li v-for="set in sets" :key="set.id" :class="{ active: set.id === activeSetId }">
+            <input
+              v-if="renamingSetId === set.id"
+              v-model="renameDraft"
+              class="rename"
+              type="text"
+              @keydown.enter="commitRename(set)"
+              @keydown.esc="renamingSetId = null"
+              @blur="commitRename(set)"
+            />
+            <button v-else type="button" class="set-name" @click="chooseActiveSet(set.id)">
+              <span class="name">{{ set.name }}</span>
+              <span class="group-count">{{ set.cardCount }}</span>
+            </button>
             <div class="row-actions">
+              <button type="button" title="Rename this set" @click="startRename(set)">
+                <font-awesome-icon icon="pen" />
+              </button>
+              <button type="button" :title="`Export ${set.name}`" @click="exportSet(set)">
+                <font-awesome-icon icon="download" />
+              </button>
               <button
                 type="button"
-                :class="{ on: setFullySelected(setCards) }"
-                :title="setFullySelected(setCards) ? `Deselect ${set}` : `Select every card in ${set}`"
-                @click="toggleSet(setCards)"
+                class="delete"
+                title="Delete this set and its cards"
+                @click="dropSet(set)"
               >
+                <font-awesome-icon icon="trash" />
+              </button>
+            </div>
+          </li>
+        </ul>
+
+        <form class="new-set" @submit.prevent="addSet">
+          <input v-model="newSetName" type="text" placeholder="New set name" @keydown.stop />
+          <button type="submit" :disabled="!newSetName.trim()">Add</button>
+        </form>
+
+        <template v-if="activeSet">
+          <div class="group-head">
+            <h3>{{ activeSet.name }}</h3>
+            <span class="group-count">{{ activeCards.length }}</span>
+            <div class="row-actions">
+              <button type="button" :disabled="!activeCards.length" title="Select every card" @click="selectAll">
                 <font-awesome-icon icon="check-double" />
               </button>
-              <button type="button" :title="`Export ${set}`" @click="exportSet(set, setCards)">
+              <button
+                type="button"
+                :disabled="!selected.length"
+                :title="`Export ${selected.length} selected`"
+                @click="exportSelected"
+              >
                 <font-awesome-icon icon="download" />
+              </button>
+              <button type="button" :disabled="!selected.length" title="Clear selection" @click="clearSelection">
+                <font-awesome-icon icon="times" />
               </button>
             </div>
           </div>
-          <ul class="library-list">
+
+          <p v-if="!activeCards.length" class="muted">
+            Nothing in this set yet. Build a card and it lands here.
+          </p>
+          <ul v-else class="library-list">
             <li
-              v-for="card in setCards"
+              v-for="card in activeCards"
               :key="card.def.cardCode"
               :class="{ editing: editingCode === card.def.cardCode }"
             >
@@ -333,7 +479,7 @@ async function onImportArkhamBuild(event: Event) {
               </div>
             </li>
           </ul>
-        </div>
+        </template>
       </template>
       </div>
     </aside>
@@ -349,11 +495,14 @@ async function onImportArkhamBuild(event: Event) {
         >
           » Library
         </button>
-        <h2>{{ editingCode ? 'Editing card' : 'New card' }}</h2>
+        <h2>
+          {{ editingCode ? 'Editing card' : 'New card' }}
+          <small v-if="activeSet" class="in-set">in {{ activeSet.name }}</small>
+        </h2>
         <div class="builder-actions">
           <span v-if="status" class="status">{{ status }}</span>
           <span v-if="error" class="error">{{ error }}</span>
-          <button type="button" :disabled="busy" @click="save">
+          <button type="button" :disabled="busy || !activeSetId" @click="save">
             {{ editingCode ? 'Save changes' : 'Create card' }}
           </button>
           <button v-if="editingCode" type="button" class="secondary" @click="startNew">New card</button>
@@ -372,7 +521,20 @@ async function onImportArkhamBuild(event: Event) {
         copies put into play after the save.
       </p>
 
-      <CustomCardForm ref="form" />
+      <!-- A card belongs to a set, so there is nothing to build until there is
+           one to build it into. -->
+      <form v-if="libraryLoaded && !activeSetId" class="first-set" @submit.prevent="addSet">
+        <h3>Make a set first</h3>
+        <p class="muted">
+          Cards are built into a set — the thing you name, export, and can throw away in one go.
+        </p>
+        <div class="first-set-row">
+          <input v-model="newSetName" type="text" placeholder="My Expansion" @keydown.stop />
+          <button type="submit" :disabled="!newSetName.trim()">Create set</button>
+        </div>
+      </form>
+
+      <CustomCardForm v-else ref="form" />
     </main>
     </div>
   </div>
@@ -507,8 +669,120 @@ async function onImportArkhamBuild(event: Event) {
   }
 }
 
-.import.wide {
-  grid-column: 1 / -1;
+/* The sets themselves, above the cards of whichever one is open. */
+.set-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  list-style: none;
+  margin: 0 0 0.5rem;
+  padding: 0;
+
+  li {
+    align-items: center;
+    border: 1px solid transparent;
+    border-radius: 6px;
+    display: grid;
+    gap: 0.35rem;
+    grid-template-columns: minmax(0, 1fr) auto;
+    padding: 0.25rem 0.35rem;
+
+    &:hover {
+      background: rgba(255, 255, 255, 0.04);
+    }
+
+    &.active {
+      background: rgba(255, 255, 255, 0.07);
+      border-color: var(--spooky-green);
+    }
+  }
+
+  .rename {
+    background: rgba(0, 0, 0, 0.3);
+    border: 1px solid var(--box-border);
+    border-radius: 4px;
+    color: var(--title);
+    font-size: 0.85rem;
+    min-width: 0;
+    padding: 0.15rem 0.3rem;
+    width: 100%;
+  }
+}
+
+.set-name {
+  align-items: baseline;
+  background: none;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  display: flex;
+  gap: 0.4rem;
+  min-width: 0;
+  padding: 0;
+  text-align: left;
+
+  .name {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+}
+
+.new-set {
+  display: grid;
+  gap: 0.3rem;
+  grid-template-columns: minmax(0, 1fr) auto;
+  margin-bottom: 0.9rem;
+
+  input {
+    background: rgba(0, 0, 0, 0.25);
+    border: 1px solid var(--box-border);
+    border-radius: 4px;
+    color: var(--title);
+    font-size: 0.8rem;
+    min-width: 0;
+    padding: 0.25rem 0.4rem;
+  }
+
+  button {
+    font-size: 0.75rem;
+    padding: 0.25rem 0.5rem;
+  }
+}
+
+.first-set {
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid var(--box-border);
+  border-radius: 8px;
+  padding: 1.25rem;
+
+  h3 {
+    font-family: teutonic, sans-serif;
+    font-size: 1.15em;
+    margin: 0 0 0.4rem;
+  }
+}
+
+.first-set-row {
+  display: flex;
+  gap: 0.5rem;
+  max-width: 28rem;
+
+  input {
+    background: rgba(0, 0, 0, 0.25);
+    border: 1px solid var(--box-border);
+    border-radius: 4px;
+    color: var(--title);
+    flex: 1 1 auto;
+    min-width: 0;
+    padding: 0.35rem 0.5rem;
+  }
+}
+
+.in-set {
+  font-family: sans-serif;
+  font-size: 0.6em;
+  opacity: 0.6;
 }
 
 .group-head {

--- a/frontend/src/arkham/views/CardBuilder.vue
+++ b/frontend/src/arkham/views/CardBuilder.vue
@@ -366,7 +366,7 @@ async function onImportArkhamBuild(event: Event) {
         <button
           type="button"
           class="library-collapse"
-          title="Hide library"
+          v-tooltip="'Hide library'" aria-label="Hide library"
           @click="libraryCollapsed = true"
         >
           «
@@ -407,16 +407,16 @@ async function onImportArkhamBuild(event: Event) {
               <span class="group-count">{{ set.cardCount }}</span>
             </button>
             <div class="row-actions">
-              <button type="button" title="Rename this set" @click="startRename(set)">
+              <button type="button" v-tooltip="'Rename this set'" aria-label="Rename this set" @click="startRename(set)">
                 <font-awesome-icon icon="pen" />
               </button>
-              <button type="button" :title="`Export ${set.name}`" @click="exportSet(set)">
+              <button type="button" v-tooltip="`Export ${set.name}`" :aria-label="`Export ${set.name}`" @click="exportSet(set)">
                 <font-awesome-icon icon="download" />
               </button>
               <button
                 type="button"
                 class="delete"
-                title="Delete this set and its cards"
+                v-tooltip="'Delete this set and its cards'" aria-label="Delete this set and its cards"
                 @click="dropSet(set)"
               >
                 <font-awesome-icon icon="trash" />
@@ -435,18 +435,18 @@ async function onImportArkhamBuild(event: Event) {
             <h3>{{ activeSet.name }}</h3>
             <span class="group-count">{{ activeCards.length }}</span>
             <div class="row-actions">
-              <button type="button" :disabled="!activeCards.length" title="Select every card" @click="selectAll">
+              <button type="button" :disabled="!activeCards.length" v-tooltip="'Select every card'" aria-label="Select every card" @click="selectAll">
                 <font-awesome-icon icon="check-double" />
               </button>
               <button
                 type="button"
                 :disabled="!selected.length"
-                :title="`Export ${selected.length} selected`"
+                v-tooltip="`Export ${selected.length} selected`" :aria-label="`Export ${selected.length} selected`"
                 @click="exportSelected"
               >
                 <font-awesome-icon icon="download" />
               </button>
-              <button type="button" :disabled="!selected.length" title="Clear selection" @click="clearSelection">
+              <button type="button" :disabled="!selected.length" v-tooltip="'Clear selection'" aria-label="Clear selection" @click="clearSelection">
                 <font-awesome-icon icon="times" />
               </button>
             </div>
@@ -470,10 +470,10 @@ async function onImportArkhamBuild(event: Event) {
                 </span>
               </button>
               <div class="row-actions">
-                <button type="button" title="Export this card" @click="exportOne(card)">
+                <button type="button" v-tooltip="'Export this card'" aria-label="Export this card" @click="exportOne(card)">
                   <font-awesome-icon icon="download" />
                 </button>
-                <button type="button" class="delete" title="Delete this card" @click="remove(card)">
+                <button type="button" class="delete" v-tooltip="'Delete this card'" aria-label="Delete this card" @click="remove(card)">
                   <font-awesome-icon icon="trash" />
                 </button>
               </div>
@@ -490,7 +490,7 @@ async function onImportArkhamBuild(event: Event) {
           v-if="libraryCollapsed"
           type="button"
           class="library-expand"
-          title="Show library"
+          v-tooltip="'Show library'" aria-label="Show library"
           @click="libraryCollapsed = false"
         >
           » Library
@@ -824,7 +824,17 @@ async function onImportArkhamBuild(event: Event) {
   gap: 0.35rem;
   list-style: none;
   margin: 0;
-  padding: 0;
+  /* Right padding keeps the scrollbar clear of the row buttons. */
+  padding: 0 0.25rem 0 0;
+
+  /* The card list is the one part of the library that grows without bound: a
+   * full imported set ran to a few thousand pixels and took the page with it.
+   * Cap it and give it its own scroller, so the head, tools and set list stay
+   * put while only the cards move. `contain` stops a scroll that reaches the
+   * end of the list from chaining on to the page behind it. */
+  max-height: 60vh;
+  overflow-y: auto;
+  overscroll-behavior: contain;
 
   /* Checkbox, art, text, actions: a fixed grid so the type never collides with
    * the buttons and the row never wraps to two lines. */

--- a/frontend/src/arkham/views/CardBuilder.vue
+++ b/frontend/src/arkham/views/CardBuilder.vue
@@ -211,6 +211,40 @@ async function onImport(event: Event) {
     error.value = 'Could not read that file.'
   }
 }
+
+/* A different source format from `onImport` above: an arkham.build ("Arkham
+ * Card Maker") card-pool export, not this app's own `.arkhamcard.json`. Only
+ * the simple fields come across -- name, type, class, cost, stats, traits,
+ * art -- never ability text, which this app has no field for at all. Cards
+ * are coded deterministically from their arkham.build id, so a deck built on
+ * arkham.build against these same cards resolves against these rows instead
+ * of going missing, and re-importing the same file updates them in place. */
+async function onImportArkhamBuild(event: Event) {
+  const input = event.target as HTMLInputElement
+  const file = input.files?.[0]
+  input.value = ''
+  if (!file) return
+
+  error.value = null
+  status.value = null
+  try {
+    const { parseArkhamBuildCards, arkhamBuildCardToCustomCard } = await import('@/arkham/arkhamBuildImport')
+    const { packName, cards: rawCards } = parseArkhamBuildCards(await file.text())
+    if (!rawCards.length) {
+      error.value = 'That file has no cards in it.'
+      return
+    }
+    if (!confirm(`Import ${rawCards.length} card${rawCards.length === 1 ? '' : 's'} from this file?`)) return
+
+    const built = rawCards.map((raw: any) => arkhamBuildCardToCustomCard(raw, packName))
+    const saved = await importLibraryCards(built)
+    registerCustomCards(saved)
+    status.value = `Imported ${saved.length} card${saved.length === 1 ? '' : 's'}.`
+  } catch (e) {
+    console.error(e)
+    error.value = 'Could not read that file as an arkham.build export.'
+  }
+}
 </script>
 
 <template>
@@ -245,6 +279,10 @@ async function onImport(event: Event) {
         <button type="button" class="tool" :disabled="!selected.length" @click="clearSelection">
           Clear
         </button>
+        <label class="tool import wide">
+          <span>Import arkham.build</span>
+          <input type="file" accept="application/json,.json" @change="onImportArkhamBuild" />
+        </label>
       </div>
 
       <p v-if="!libraryLoaded" class="muted">Loading…</p>
@@ -467,6 +505,10 @@ async function onImport(event: Event) {
   input {
     display: none;
   }
+}
+
+.import.wide {
+  grid-column: 1 / -1;
 }
 
 .group-head {

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -9,13 +9,13 @@ import router from './router'
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { library } from "@fortawesome/fontawesome-svg-core";
 import { faExpeditedssl } from "@fortawesome/free-brands-svg-icons";
-import { faGear, faLayerGroup, faBan, faCircleExclamation, faGhost, faLocationDot, faSearch, faList, faImage, faAngleDown, faUndo, faTrash, faEye, faCopy, faExternalLink, faRefresh, faBook, faChevronRight, faBars, faTimes, faShieldHeart, faWrench, faPaperclip, faArrowLeft, faArrowUp, faStore, faTriangleExclamation, faShuffle, faTrophy, faDownload, faCheckDouble, faFlask, faBug } from '@fortawesome/free-solid-svg-icons'
+import { faGear, faLayerGroup, faBan, faCircleExclamation, faGhost, faLocationDot, faSearch, faList, faImage, faAngleDown, faUndo, faTrash, faEye, faCopy, faExternalLink, faRefresh, faBook, faChevronRight, faBars, faTimes, faShieldHeart, faWrench, faPaperclip, faArrowLeft, faArrowUp, faStore, faTriangleExclamation, faShuffle, faTrophy, faDownload, faCheckDouble, faFlask, faBug, faPen } from '@fortawesome/free-solid-svg-icons'
 import * as VueI18n from 'vue-i18n'
 import { loadLocaleMessages, normalizeLocale } from '@/locales/messages'
 import { preferredLanguage } from '@/locales/language'
 import mitt from 'mitt';
 
-library.add(faBan, faLocationDot, faCircleExclamation, faGhost, faSearch, faList, faImage, faAngleDown, faExpeditedssl, faUndo, faTrash, faEye, faCopy, faExternalLink, faRefresh, faBook, faChevronRight, faBars, faTimes, faShieldHeart, faWrench, faPaperclip, faArrowLeft, faArrowUp, faStore, faTriangleExclamation, faShuffle, faTrophy, faGear, faLayerGroup, faDownload, faCheckDouble, faFlask, faBug)
+library.add(faBan, faLocationDot, faCircleExclamation, faGhost, faSearch, faList, faImage, faAngleDown, faExpeditedssl, faUndo, faTrash, faEye, faCopy, faExternalLink, faRefresh, faBook, faChevronRight, faBars, faTimes, faShieldHeart, faWrench, faPaperclip, faArrowLeft, faArrowUp, faStore, faTriangleExclamation, faShuffle, faTrophy, faGear, faLayerGroup, faDownload, faCheckDouble, faFlask, faBug, faPen)
 
 async function bootstrap() {
   const language = localStorage.getItem('language')

--- a/frontend/tests/arkhamBuildImport.test.mjs
+++ b/frontend/tests/arkhamBuildImport.test.mjs
@@ -250,3 +250,34 @@ test('an alternate front is rewritten inside the meta string', async (t) => {
   // Everything else in meta survives the rewrite.
   assert.equal(meta.faction_selected, 'guardian')
 })
+
+/* A pack's cards arrive with a short hex id rather than a dashed UUID. Both the
+ * import and the deck have to derive the same code from it, or the deck names a
+ * card the library holds under a different code and validation rejects it as
+ * unimplemented -- reported as a bare `Unknown card: c1C8082CF`. */
+test('a short arkham.build id matches the code its card was imported under', async (t) => {
+  const { arkhamBuildCardToCustomCard, normalizeArkhamBuildDeckCodes } = await load(t)
+
+  const shortId = '1C8082CF'
+  const card = arkhamBuildCardToCustomCard({ ...asset, code: shortId }, PACK)
+
+  const deck = normalizeArkhamBuildDeckCodes({
+    investigator_code: '01001',
+    slots: { [shortId]: 2 },
+  })
+
+  // The deck now names the card by the same code the library stored it under,
+  // and case does not matter: the deck spells it upper, the code is lower.
+  assert.deepEqual(Object.keys(deck.slots), [card.def.cardCode])
+  assert.equal(card.def.cardCode, '*1c8082cf0')
+})
+
+test('an undashed 32-character uuid is translated too', async (t) => {
+  const { arkhamBuildCardToCustomCard, normalizeArkhamBuildDeckCodes } = await load(t)
+
+  const bare = '43433775620b4e108583253eb3f3e6c2'
+  const card = arkhamBuildCardToCustomCard({ ...asset, code: bare }, PACK)
+  const deck = normalizeArkhamBuildDeckCodes({ investigator_code: '01001', slots: { [bare]: 1 } })
+
+  assert.deepEqual(Object.keys(deck.slots), [card.def.cardCode])
+})

--- a/frontend/tests/arkhamBuildImport.test.mjs
+++ b/frontend/tests/arkhamBuildImport.test.mjs
@@ -1,0 +1,252 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { fileURLToPath, URL } from 'node:url'
+
+import { createServer } from 'vite'
+
+/* Importing an arkham.build card pool and later importing a DECK built on
+arkham.build against those same cards have to agree on one thing: the card
+code. arkham.build names a card by a bare UUID; this app only ever recognizes
+a custom card by a `*`-prefixed code (isCustomCardCode), both in the frontend
+lookups and in the backend's deck validation. So the importer derives a code
+from the UUID, and the deck normalizer derives it again from the same UUID --
+and if those two derivations ever drift apart, a deck silently loses every
+custom card in it.
+
+That agreement is what these tests pin. The field mapping is checked alongside
+it because the same module owns both. */
+async function load(t) {
+  const server = await createServer({
+    root: fileURLToPath(new URL('..', import.meta.url)),
+    appType: 'custom',
+    logLevel: 'silent',
+    server: { middlewareMode: true, hmr: false },
+  })
+  t.after(() => server.close())
+  return server.ssrLoadModule('/src/arkham/arkhamBuildImport.ts')
+}
+
+const PACK = 'Return to the Zealot'
+
+const investigator = {
+  code: 'd545b38e-f3cf-486a-a026-12ed94b33453',
+  position: 1,
+  name: 'Roland Banks',
+  subname: 'The Fed',
+  type_code: 'investigator',
+  faction_code: 'guardian',
+  skill_willpower: 3,
+  skill_intellect: 3,
+  skill_combat: 4,
+  skill_agility: 2,
+  health: 9,
+  sanity: 5,
+  is_unique: true,
+  traits: 'Agency. Detective.',
+  image_url: 'https://example.test/roland-front.jpg',
+  back_image_url: 'https://example.test/roland-back.jpg',
+}
+
+const asset = {
+  code: '43433775-620b-4e10-8583-253eb3f3e6c2',
+  position: 2,
+  name: "Roland's .38 Special",
+  type_code: 'asset',
+  faction_code: 'neutral',
+  cost: 3,
+  xp: 0,
+  skill_willpower: 1,
+  skill_combat: 1,
+  skill_wild: 1,
+  slot: 'Hand',
+  traits: 'Item. Weapon. Firearm.',
+  is_unique: true,
+  image_url: 'https://example.test/38-special.jpg',
+}
+
+const weaknessTreachery = {
+  code: '3497e84b-9698-4d54-937c-65096eb6c82c',
+  position: 3,
+  name: 'Cover Up',
+  type_code: 'treachery',
+  faction_code: 'neutral',
+  subtype_code: 'weakness',
+  traits: 'Task.',
+}
+
+const weaknessEnemy = {
+  code: '4ac58d97-9521-4609-bcc0-a1d88d494289',
+  position: 124,
+  name: 'Issith',
+  type_code: 'enemy',
+  faction_code: 'neutral',
+  subtype_code: 'weakness',
+  enemy_fight: 3,
+  health: 3,
+  enemy_evade: 2,
+  enemy_damage: 1,
+  enemy_horror: 1,
+  traits: 'Humanoid. Monster. Serpent.',
+}
+
+const poolFile = JSON.stringify({
+  meta: { name: PACK, code: 'cae9cd37-4621-4e52-958c-40a250f730b6' },
+  data: { cards: [investigator, asset, weaknessTreachery, weaknessEnemy] },
+})
+
+test('a card pool export yields its pack name and every card', async (t) => {
+  const { parseArkhamBuildCards } = await load(t)
+
+  const { packName, cards } = parseArkhamBuildCards(poolFile)
+  assert.equal(packName, PACK)
+  assert.equal(cards.length, 4)
+})
+
+test('a pack carries its own id, so a renamed pack still replaces its set', async (t) => {
+  const { parseArkhamBuildCards } = await load(t)
+
+  const { packCode } = parseArkhamBuildCards(poolFile)
+  assert.equal(packCode, 'cae9cd37-4621-4e52-958c-40a250f730b6')
+
+  // Same pack, renamed: the id is what says it is the same set.
+  const renamed = JSON.stringify({
+    meta: { name: 'Return to the Zealot (revised)', code: 'cae9cd37-4621-4e52-958c-40a250f730b6' },
+    data: { cards: [asset] },
+  })
+  assert.equal(parseArkhamBuildCards(renamed).packCode, packCode)
+
+  // A file with no pack id at all says so rather than inventing one.
+  assert.equal(parseArkhamBuildCards(JSON.stringify({ cards: [asset] })).packCode, null)
+})
+
+test('a bare card array and a lone card both parse', async (t) => {
+  const { parseArkhamBuildCards } = await load(t)
+
+  assert.equal(parseArkhamBuildCards(JSON.stringify({ cards: [asset] })).cards.length, 1)
+  assert.equal(parseArkhamBuildCards(JSON.stringify(asset)).cards.length, 1)
+  // Something that is not a card export at all yields nothing rather than a card.
+  assert.equal(parseArkhamBuildCards(JSON.stringify({ nope: true })).cards.length, 0)
+})
+
+test('an investigator keeps its stats, class and both faces', async (t) => {
+  const { arkhamBuildCardToCustomCard } = await load(t)
+
+  const { def, art } = arkhamBuildCardToCustomCard(investigator, PACK)
+  assert.equal(def.cardType, 'InvestigatorType')
+  assert.deepEqual(def.name, { title: 'Roland Banks', subtitle: 'The Fed' })
+  assert.deepEqual(def.classSymbols, ['Guardian'])
+  assert.equal(def.unique, true)
+  assert.deepEqual(def.cardTraits, ['Agency', 'Detective'])
+  // On an investigator `skill_*` is a printed stat, not a count of icons.
+  assert.deepEqual(def.skills, [])
+  assert.equal(def.meta.willpower, 3)
+  assert.equal(def.meta.combat, 4)
+  assert.equal(def.meta.health, 9)
+  assert.equal(def.meta.sanity, 5)
+  assert.equal(art, investigator.image_url)
+  assert.equal(def.meta.backArt, investigator.back_image_url)
+})
+
+test('a player asset keeps cost, icons and slot', async (t) => {
+  const { arkhamBuildCardToCustomCard } = await load(t)
+
+  const { def } = arkhamBuildCardToCustomCard(asset, PACK)
+  assert.equal(def.cardType, 'AssetType')
+  assert.deepEqual(def.cost, { tag: 'StaticCost', contents: 3 })
+  assert.deepEqual(def.slots, ['HandSlot'])
+  // Here `skill_*` IS a count of printed icons -- one pip each, wild last.
+  assert.deepEqual(def.skills, [
+    { tag: 'SkillIcon', contents: 'SkillWillpower' },
+    { tag: 'SkillIcon', contents: 'SkillCombat' },
+    { tag: 'WildIcon', contents: [] },
+  ])
+})
+
+test('a weakness lands on the player-side type for its kind', async (t) => {
+  const { arkhamBuildCardToCustomCard } = await load(t)
+
+  const treachery = arkhamBuildCardToCustomCard(weaknessTreachery, PACK).def
+  assert.equal(treachery.cardType, 'PlayerTreacheryType')
+  assert.equal(treachery.cardSubType, 'Weakness')
+  // A weakness has no class of its own, so none is claimed for it.
+  assert.equal(treachery.classSymbols, undefined)
+
+  const enemy = arkhamBuildCardToCustomCard(weaknessEnemy, PACK).def
+  assert.equal(enemy.cardType, 'PlayerEnemyType')
+  assert.deepEqual(enemy.fight, { tag: 'Static', contents: 3 })
+  assert.deepEqual(enemy.health, { tag: 'Static', contents: 3 })
+  assert.deepEqual(enemy.evade, { tag: 'Static', contents: 2 })
+  assert.deepEqual(enemy.healthDamage, { tag: 'Static', contents: 1 })
+  assert.deepEqual(enemy.sanityDamage, { tag: 'Static', contents: 1 })
+})
+
+test('ability text is never imported -- there is no field for it', async (t) => {
+  const { arkhamBuildCardToCustomCard } = await load(t)
+
+  const { def } = arkhamBuildCardToCustomCard(
+    { ...asset, text: 'Spend 1 ammo: Fight.', flavor: 'Bang.' },
+    PACK,
+  )
+  const blob = JSON.stringify(def)
+  assert.ok(!blob.includes('Spend 1 ammo'))
+  assert.ok(!blob.includes('Bang.'))
+})
+
+test('a card code is derived from the arkham.build id, not minted fresh', async (t) => {
+  const { arkhamBuildCardToCustomCard } = await load(t)
+
+  const once = arkhamBuildCardToCustomCard(asset, PACK).def.cardCode
+  const again = arkhamBuildCardToCustomCard(asset, PACK).def.cardCode
+  // Re-importing the same file has to land on the same code, or it would
+  // duplicate the card instead of updating it.
+  assert.equal(once, again)
+  // isCustomCardCode is a `*` prefix check, and the engine's CardCode equality
+  // treats a trailing a/b/c/d as a card side, so the code ends in a digit.
+  assert.ok(once.startsWith('*'))
+  assert.match(once, /^\*[0-9a-f]{32}0$/)
+})
+
+test('a deck names the same cards the import stored', async (t) => {
+  const { arkhamBuildCardToCustomCard, normalizeArkhamBuildDeckCodes } = await load(t)
+
+  const deck = normalizeArkhamBuildDeckCodes({
+    investigator_code: investigator.code,
+    slots: { [asset.code]: 1, [weaknessTreachery.code]: 1, '01001': 2 },
+    sideSlots: { [weaknessEnemy.code]: 1 },
+  })
+
+  assert.equal(deck.investigator_code, arkhamBuildCardToCustomCard(investigator, PACK).def.cardCode)
+  for (const card of [asset, weaknessTreachery]) {
+    const code = arkhamBuildCardToCustomCard(card, PACK).def.cardCode
+    assert.ok(code in deck.slots, `${card.name} is not in the deck under ${code}`)
+  }
+  assert.ok(arkhamBuildCardToCustomCard(weaknessEnemy, PACK).def.cardCode in deck.sideSlots)
+  // Quantities ride along untouched.
+  assert.equal(deck.slots['01001'], 2)
+})
+
+test('an official card code is left exactly as it was', async (t) => {
+  const { normalizeArkhamBuildDeckCodes } = await load(t)
+
+  const deck = normalizeArkhamBuildDeckCodes({
+    investigator_code: '01001',
+    slots: { '01006': 2, '60505': 1, c01007: 1 },
+  })
+  assert.equal(deck.investigator_code, '01001')
+  assert.deepEqual(deck.slots, { '01006': 2, '60505': 1, c01007: 1 })
+})
+
+test('an alternate front is rewritten inside the meta string', async (t) => {
+  const { arkhamBuildCardToCustomCard, normalizeArkhamBuildDeckCodes } = await load(t)
+
+  const deck = normalizeArkhamBuildDeckCodes({
+    investigator_code: investigator.code,
+    slots: {},
+    meta: JSON.stringify({ alternate_front: investigator.code, faction_selected: 'guardian' }),
+  })
+
+  const meta = JSON.parse(deck.meta)
+  assert.equal(meta.alternate_front, arkhamBuildCardToCustomCard(investigator, PACK).def.cardCode)
+  // Everything else in meta survives the rewrite.
+  assert.equal(meta.faction_selected, 'guardian')
+})

--- a/frontend/tests/customCardExport.test.mjs
+++ b/frontend/tests/customCardExport.test.mjs
@@ -1,0 +1,111 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { fileURLToPath, URL } from 'node:url'
+
+import { createServer } from 'vite'
+
+/* Every custom card belongs to a set, so every import has to land in one --
+including a file that predates sets, or a single card pasted on its own. What
+set that is decides whether an import replaces something you already have or
+quietly makes a second copy of it beside the first, so the fallbacks are pinned
+here rather than left to whatever the file happens to carry. */
+async function load(t) {
+  const server = await createServer({
+    root: fileURLToPath(new URL('..', import.meta.url)),
+    appType: 'custom',
+    logLevel: 'silent',
+    server: { middlewareMode: true, hmr: false },
+  })
+  t.after(() => server.close())
+  return server.ssrLoadModule('/src/arkham/customCardLibrary.ts')
+}
+
+const card = (title, setName) => ({
+  def: {
+    cardCode: `*${title.toLowerCase()}0`,
+    name: { title },
+    cardType: 'AssetType',
+    ...(setName === undefined ? {} : { meta: { set: setName } }),
+  },
+  art: null,
+})
+
+test('an export names the set it came from', async (t) => {
+  const { exportCards, EXPORT_VERSION } = await load(t)
+
+  const file = await exportCards([card('One', 'Zealot')], {
+    id: 'set-1',
+    name: 'Zealot',
+    sourceCode: 'pack-1',
+    cardCount: 1,
+    updatedAt: '2026-01-01T00:00:00Z',
+  })
+
+  assert.equal(file.version, EXPORT_VERSION)
+  assert.deepEqual(file.set, { name: 'Zealot', sourceCode: 'pack-1' })
+  assert.equal(file.cards.length, 1)
+})
+
+test('an export of loose cards names no set', async (t) => {
+  const { exportCards } = await load(t)
+
+  const file = await exportCards([card('One', 'Zealot')])
+  assert.equal(file.set, undefined)
+})
+
+test('an import reads the set the file names', async (t) => {
+  const { parseCardExport } = await load(t)
+
+  const parsed = parseCardExport(
+    JSON.stringify({
+      version: 2,
+      set: { name: 'Zealot', sourceCode: 'pack-1' },
+      cards: [card('One', 'Zealot')],
+    }),
+    'whatever.json',
+  )
+
+  assert.equal(parsed.name, 'Zealot')
+  assert.equal(parsed.sourceCode, 'pack-1')
+  assert.equal(parsed.cards.length, 1)
+})
+
+test('a file from before sets falls back to what its cards claim', async (t) => {
+  const { parseCardExport } = await load(t)
+
+  // Version 1: cards only, each naming its set the old way.
+  const parsed = parseCardExport(
+    JSON.stringify({ version: 1, cards: [card('One', 'Dunwich'), card('Two', 'Dunwich')] }),
+    'ignored',
+  )
+  assert.equal(parsed.name, 'Dunwich')
+  assert.equal(parsed.sourceCode, null)
+  assert.equal(parsed.cards.length, 2)
+})
+
+test('a file that names no set anywhere falls back to the file name', async (t) => {
+  const { parseCardExport } = await load(t)
+
+  assert.equal(parseCardExport(JSON.stringify({ cards: [card('One')] }), 'my-cards').name, 'my-cards')
+  // A blank set name is no name at all.
+  assert.equal(parseCardExport(JSON.stringify({ cards: [card('One', '   ')] }), 'my-cards').name, 'my-cards')
+})
+
+test('a single card pasted on its own still imports', async (t) => {
+  const { parseCardExport } = await load(t)
+
+  const parsed = parseCardExport(JSON.stringify(card('Lonely', 'Zealot')), 'lonely')
+  assert.equal(parsed.cards.length, 1)
+  assert.equal(parsed.name, 'Zealot')
+})
+
+test('anything without a card code is not a card', async (t) => {
+  const { parseCardExport } = await load(t)
+
+  const parsed = parseCardExport(
+    JSON.stringify({ cards: [card('Real', 'Zealot'), { def: { name: { title: 'Junk' } }, art: null }] }),
+    'file',
+  )
+  assert.equal(parsed.cards.length, 1)
+  assert.equal(parsed.cards[0].def.name.title, 'Real')
+})

--- a/migrations/deploy/arkham_custom_card_sets.sql
+++ b/migrations/deploy/arkham_custom_card_sets.sql
@@ -1,0 +1,71 @@
+-- Deploy arkham-horror-backend:arkham_custom_card_sets to pg
+-- requires: users
+-- requires: arkham_custom_cards
+
+BEGIN;
+
+-- Named collections that own custom cards: the unit you build, export, and hand
+-- to someone else. Grouping used to be a string each card carried in its own
+-- def, which meant a set existed only as far as every one of its cards agreed
+-- on the spelling, and throwing one away meant deleting its cards one at a
+-- time.
+--
+-- source_code is the id of the pack an imported set came from (arkham.build
+-- gives one), so importing that pack again replaces this set rather than making
+-- a second copy of it. A set built here has none.
+
+CREATE TABLE IF NOT EXISTS arkham_custom_card_sets (
+  id uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+  user_id bigint REFERENCES users (id) ON DELETE CASCADE NOT NULL,
+  name varchar NOT NULL,
+  source_code varchar,
+  created_at timestamptz NOT NULL,
+  updated_at timestamptz NOT NULL,
+  CONSTRAINT unique_user_custom_card_set_name UNIQUE (user_id, name)
+);
+
+ALTER TABLE arkham_custom_cards
+  ADD COLUMN IF NOT EXISTS custom_card_set_id uuid
+  REFERENCES arkham_custom_card_sets (id) ON DELETE CASCADE;
+
+-- Cards that predate sets are put into one named after whatever they were
+-- claiming for themselves, so nobody's library arrives here ungrouped.
+INSERT INTO arkham_custom_card_sets (user_id, name, created_at, updated_at)
+SELECT DISTINCT
+    c.user_id,
+    COALESCE(NULLIF(TRIM(c.def -> 'meta' ->> 'set'), ''), 'Imported cards'),
+    now(),
+    now()
+  FROM arkham_custom_cards c
+ON CONFLICT ON CONSTRAINT unique_user_custom_card_set_name DO NOTHING;
+
+UPDATE arkham_custom_cards c
+   SET custom_card_set_id = s.id
+  FROM arkham_custom_card_sets s
+ WHERE s.user_id = c.user_id
+   AND s.name = COALESCE(NULLIF(TRIM(c.def -> 'meta' ->> 'set'), ''), 'Imported cards')
+   AND c.custom_card_set_id IS NULL;
+
+-- The name a card carries is only a copy of the set's, but it is the one
+-- anything looking at a def alone reads, so every card is given the name of the
+-- set it was just filed under -- including the ones whose own spelling of it
+-- (untrimmed, or absent entirely) is what put them there.
+UPDATE arkham_custom_cards c
+   SET def = jsonb_set(
+         jsonb_set(c.def, '{meta}', COALESCE(c.def -> 'meta', '{}'::jsonb), true),
+         '{meta,set}',
+         to_jsonb(s.name),
+         true
+       )
+  FROM arkham_custom_card_sets s
+ WHERE s.id = c.custom_card_set_id;
+
+-- Every card belongs to a set, now that every card has one.
+ALTER TABLE arkham_custom_cards
+  ALTER COLUMN custom_card_set_id SET NOT NULL;
+
+-- Listing, counting and emptying a set all go by this.
+CREATE INDEX IF NOT EXISTS idx_arkham_custom_cards_set
+  ON arkham_custom_cards (custom_card_set_id);
+
+COMMIT;

--- a/migrations/revert/arkham_custom_card_sets.sql
+++ b/migrations/revert/arkham_custom_card_sets.sql
@@ -1,0 +1,11 @@
+-- Revert arkham-horror-backend:arkham_custom_card_sets from pg
+
+BEGIN;
+
+DROP INDEX IF EXISTS idx_arkham_custom_cards_set;
+
+ALTER TABLE arkham_custom_cards DROP COLUMN IF EXISTS custom_card_set_id;
+
+DROP TABLE IF EXISTS arkham_custom_card_sets;
+
+COMMIT;

--- a/migrations/sqitch.plan
+++ b/migrations/sqitch.plan
@@ -21,3 +21,4 @@ arkham_game_undo_floors [arkham_games] 2026-06-29T12:00:00Z Matthew Mongeau <hal
 arkham_achievements [arkham_games users] 2026-07-09T00:00:00Z Matthew Mongeau <halogenandtoast@Mac-Studio.local> # Above-the-table achievements per user
 arkham_custom_cards [users] 2026-09-05T00:00:00Z Matthew Mongeau <halogenandtoast@Mac-Studio.local> # Cards built in the card builder, kept per user
 arkham_deck_overlay [arkham_decks] 2026-09-05T12:00:00Z Matthew Mongeau <halogenandtoast@Mac-Studio.local> # Custom card overlay laid over a deck
+arkham_custom_card_sets [users arkham_custom_cards] 2026-09-11T00:00:00Z Claude <noreply@anthropic.com> # Named collections that own custom cards

--- a/migrations/verify/arkham_custom_card_sets.sql
+++ b/migrations/verify/arkham_custom_card_sets.sql
@@ -1,0 +1,13 @@
+-- Verify arkham-horror-backend:arkham_custom_card_sets on pg
+
+BEGIN;
+
+SELECT id, user_id, name, source_code, created_at, updated_at
+  FROM arkham_custom_card_sets
+ WHERE FALSE;
+
+SELECT custom_card_set_id
+  FROM arkham_custom_cards
+ WHERE FALSE;
+
+ROLLBACK;


### PR DESCRIPTION
Two related changes to the card builder, the second building on the first.

## Importing an arkham.build card pool

The builder could only take cards one at a time. This adds an "Import
arkham.build" control that takes an arkham.build card-pool json export and
creates the whole pool at once, mapping only the simple fields: name, subtitle,
type, class, cost, level, skill icons, slot, traits, unique/permanent, weakness
kind, enemy stats, and art (front, plus the back for an investigator).

Ability text is deliberately not imported. There is no free-text ability field
to put it in — abilities are authored structurally through AbilityEditor /
StepsEditor — so an imported card looks and stats out correctly but does
nothing until someone builds that by hand. The pack's rendered card image
carries the printed text, so it is still readable on the card face.

The point of it is the codes. arkham.build names a custom card by its own bare
id, and nothing here will attempt a custom-card lookup unless the code starts
with `*` (`isCustomCardCode`, checked identically in the frontend and in
`toDeckErrors`). So the importer derives this app's code from the
arkham.build id deterministically, and a deck arriving from arkham.build — by
file or by share URL — has the same derivation applied to its `slots`,
`sideSlots`, `investigator_code` and `meta.alternate_front` before it reaches
validation. Without both halves a deck built against these cards fails as
`UnimplementedCard` even though the cards are sitting in the library.

## Sets as a real entity

Grouping was a string each card carried in its own def, so a set existed only
as far as every one of its cards agreed on the spelling, renaming one meant
editing every card, and discarding a 150-card import meant deleting 150 cards.

A set is a row now (`arkham_custom_card_sets`), owned by a user, and every card
belongs to one:

- The builder asks for a set before it will build anything, and writes new
  cards into the active one. Editing a card keeps it in its own set.
- Deleting a set deletes its cards.
- Importing is per set and replaces rather than merges — the file is the set as
  it now stands, so a card it no longer contains is a card the set no longer
  contains. An arkham.build pack is matched on its own pack id, so a renamed
  pack still replaces the set it made; this app's own exports now name the set
  they came from.
- The name each card still carries is a copy the server stamps from the set, so
  the deck overlay, the card picker and a card exported on its own keep reading
  it, and a rename rewrites them.

`POST /custom-cards` now requires a set id; `POST /custom-cards/import` is
replaced by `POST /custom-card-sets/import`.

## Migration

`migrations/deploy/arkham_custom_card_sets.sql` creates the table, adds the FK
to `arkham_custom_cards`, backfills existing cards into sets named after
whatever `meta.set` they were carrying (blank or missing becomes "Imported
cards"), then makes the column NOT NULL.

Verified against a real Postgres with seeded data covering each backfill case
(a name, a whitespace-padded name, a blank one, no meta at all, and a second
user with a same-named set): applies cleanly, is idempotent, keeps other meta
keys, enforces the NOT NULL, cascades per user, and reverts cleanly.

## Testing

- `frontend/tests/arkhamBuildImport.test.mjs` and
  `frontend/tests/customCardExport.test.mjs` cover the field mapping, the
  code derivation, the deck-code rewrite agreeing with the importer, official
  ArkhamDB codes being left alone, and the set-name fallbacks on import.
- `npm run tc` and `eslint` are clean; the suite passes apart from two
  failures that are already present on main.
